### PR TITLE
Update Home-assistant url

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Discussions: <https://github.com/smart-swimmingpool/smart-swimmingpool.github.io
 - [x] [Homie 3.0](https://homieiot.github.io/) compatible MQTT messaging
 - [x] Independent of specific smarthome servers
   - [x] [openHAB](https://www.openhab.org) since Version 2.4 using MQTT Homie
-  - [x] [Home Assistant](home-assistant.io) using MQTT Homie
+  - [x] [Home Assistant](https://www.home-assistant.io/) using MQTT Homie
 - [x] Timesync via NTP (europe.pool.ntp.org)
 - [x] Logging-Information via Homie-Node
 


### PR DESCRIPTION
Link to home assistant was broken and was referring to https://smart-swimmingpool.com/docs/pool-controller/home-assistant.io
updated to correct url: https://www.home-assistant.io/