### PR TITLE
fix: improve English grammar and word choice in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pool Controller 2.0 | 🏊 Smart Swimmingpool
+# Pool Controller 2.0 | 🏊 Smart Swimming Pool
 
 [![Smart Swimmingpool](https://img.shields.io/badge/%F0%9F%8F%8A%20-Smart%20Swimmingpool-blue.svg)](https://github.com/smart-swimmingpool)
 [![PlatformIO CI](https://github.com/smart-swimmingpool/pool-controller/workflows/PlatformIO%20CI/badge.svg)](https://github.com/smart-swimmingpool/pool-controller/actions?query=workflow%3A%22PlatformIO+CI%22)
@@ -9,7 +9,7 @@
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/J3J33A8DT)
 
-**🏊 The Homie 3.0 compatible Smart Swimmingpool Controller 🎛️**
+**🏊 The Homie 3.0 compatible Smart Swimming Pool Controller 🎛️**
 
 Manage your swimming pool in a smart way to enjoy it comfortably and affordably (for less than 100€).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **🏊 The Homie 3.0 compatible Smart Swimmingpool Controller 🎛️**
 
-Manage your swmming pool on the smart way to enjoy it in confortable and cheap (less than 100€) way.
+Manage your swimming pool in a smart way to enjoy it comfortably and affordably (for less than 100€).
 
 Discussions: <https://github.com/smart-swimmingpool/smart-swimmingpool.github.io/discussions>
 
@@ -31,9 +31,9 @@ Discussions: <https://github.com/smart-swimmingpool/smart-swimmingpool.github.io
 - [ ] Configurable NTP Server (currently hardcoded: europe.pool.ntp.org)
 - [ ] be more smart: self learning for improved pool pump timed circulation for cleaning and heating
 - [ ] two separate circulation cycles
-- [ ] store configuration changes persistent on conroller
+- [ ] store configuration changes persistently on the controller
 - [ ] temperature based cleaning circulation time (colder == shorter, hotter == longer)
-- [ ] Improved sketch to work completly without WiFi connection
+- [ ] Improved sketch to work completely without WiFi connection
       - Homie should run without WiFi connection
       - enhance sketch using display and buttons to setup environment.
 - see also the [issue list](https://github.com/smart-swimmingpool/pool-controller/issues)

--- a/docs/_index.de.md
+++ b/docs/_index.de.md
@@ -39,7 +39,7 @@ Steuer deinen Swimming-Pool auf smarte Art und Weise, um diesen bequem und güns
 - [x] [Homie 3.0](https://homieiot.github.io/) kompatibles MQTT Nachrichtenformat
 - [x] Unabhängig von einzelnen Smarthome-Servern
   - [x] [openHAB](https://www.openhab.org) seit Version 2.4 unter Verwendung von MQTT Homie
-  - [x] [Home Assistant](home-assistant.io) unter Verwendung von MQTT Homie
+  - [x] [Home Assistant](https://home-assistant.io) unter Verwendung von MQTT Homie
 - [x] Automatische Zeitsynchroisierung mit NTP (europe.pool.ntp.org)
 - [x] Logging-Informationen via Homie-Node
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -39,7 +39,7 @@ Manage your swimming pool in a smart way to enjoy it comfortably and affordably 
 - [x] [Homie 3.0](https://homieiot.github.io/) compatible MQTT messaging
 - [x] Independent of specific smarthome servers
   - [x] [openHAB](https://www.openhab.org) since Version 2.4 using MQTT Homie
-  - [x] [Home Assistant](home-assistant.io) using MQTT Homie
+  - [x] [Home Assistant](https://home-assistant.io) using MQTT Homie
 - [x] Timesync via NTP (europe.pool.ntp.org)
 - [x] Logging-Information via Homie-Node
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -30,7 +30,7 @@ menu:
 [GitHub Sources](https://github.com/smart-swimmingpool/pool-controller)
 </span>
 
-Manage your swmming pool on the smart way to enjoy it in confortable and cheap (less than 100€) way.
+Manage your swimming pool in a smart way to enjoy it comfortably and affordably (for less than 100€).
 
 ## Main Features
 
@@ -48,9 +48,9 @@ Manage your swmming pool on the smart way to enjoy it in confortable and cheap (
 - [ ] Configurable NTP Server (currently hardcoded: europe.pool.ntp.org)
 - [ ] Be more smart: self learning for improved pool pump timed circulation for cleaning and heating
 - [ ] Two separate circulation cycles
-- [ ] Store configuration changes persistent on conroller
+- [ ] Store configuration changes persistently on the controller
 - [ ] Temperature based cleaning circulation time (colder == shorter, hotter == longer)
-- [ ] Improved sketch to work completly without WiFi connection
+- [ ] Improved sketch to work completely without WiFi connection
 - [ ] Homie should run without WiFi connection
 - [ ] Enhance sketch using display and buttons to setup environment.
 - [ ] Use only one power supply for ESP8266 (5V) and relais (230V)

--- a/docs/hardware-guide.md
+++ b/docs/hardware-guide.md
@@ -22,7 +22,7 @@ This Hardware Guide describes how to set up the hardware of the controller.
 - 1 * ESP8266 NodeMCU Controller ([Amazon](https://amzn.to/2Ze9DSh))
 - 2 * DS18B20 Temperature Sensors ([Amazon](https://amzn.to/2ZlfZ2c))
 - 1 * Relais-Module 5V ([Amazon](https://amzn.to/31RBd5s))
-- 1 * Breadboard and wires to connect (alternativly soldering of the circuit)
+- 1 * Breadboard and wires to connect (alternatively soldering of the circuit)
 
 ## Circuit
 

--- a/docs/hardware-guide.md
+++ b/docs/hardware-guide.md
@@ -15,7 +15,7 @@ menu:
     weight: 20
 ---
 
-This Hardware Guide will describe how to setup the hardware of the controller.
+This Hardware Guide describes how to set up the hardware of the controller.
 
 ## Parts List (BOM)
 
@@ -26,11 +26,11 @@ This Hardware Guide will describe how to setup the hardware of the controller.
 
 ## Circuit
 
-The circuit of the controller could be found on following image based on a breadboard wireing:
+The circuit of the controller can be found in the following image based on a breadboard wiring:
 
 {{< figure library="true" src="../pool-controller_breadboard.png" title="Breadboard Circuit of Pool Controller" lightbox="true" >}}
 
-The source [Fritzing](https://fritzing.org/) file could be found in GitHub project: [pool-controller.fzz](https://github.com/smart-swimmingpool/pool-controller/raw/main/docs/pool-controller.fzz)
+The source [Fritzing](https://fritzing.org/) file can be found in the GitHub project: [pool-controller.fzz](https://github.com/smart-swimmingpool/pool-controller/raw/main/docs/pool-controller.fzz)
 
 ### ESP8266 PIN Usage
 
@@ -50,5 +50,4 @@ TODO: improve PIN usage (see https://randomnerdtutorials.com/esp8266-pinout-refe
 
 ## Power Supply
 
-In my environment I use the USB to power the ESP8266 via small USB-Power-Adapter andan additional
-230V power plug to be used as source for the power of the pumps which are switched via the relais.
+In my environment, I use USB to power the ESP8266 via a small USB power adapter and an additional 230V power plug as the source for the power of the pumps, which are switched via the relays.

--- a/docs/software-guide.md
+++ b/docs/software-guide.md
@@ -33,7 +33,7 @@ Many thanks to maintainers of these libraries!
 
 ## Defines
 
-Within the sources at `main.cpp` there are someconstant defined settings. For the PIN assignment
+Within the sources at `main.cpp`, there are some constant settings defined. For the PIN assignment,
 see also at [hardware guide](../hardware-guide/#esp8266-pin-usage).
 
 ```cpp
@@ -81,7 +81,7 @@ How to upload JSON config files see [Homie-esp8266 docu](https://homieiot.github
 
 ### Clearing retained messages
 
-In some cases some retained messages can be wanted and we don’t want to clear all the retained messages.
+In some cases, retained messages may be desired and we don’t want to clear all the retained messages.
 
 The messages will have to be cleared one by one using the topic
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Users Guide of Pool Controller
-summary: Control your Smart Swimming Pool smart
+summary: Control your Smart Swimming Pool in a smart way
 date: "2020-05-28"
 lastmod: "2020-06-02"
 draft: false
@@ -19,7 +19,7 @@ menu:
 
 ## Booting Controller
 
-Booting the controller, it will give feedback on establishing WiFi connection andconnection to MQTT broker:
+When booting the controller, it will provide feedback on establishing the WiFi connection and connection to the MQTT broker:
 
 * "LED" ![Slowly blinking LED](led_wifi.gif)
     Slowly when connecting to the Wi-Fi
@@ -35,12 +35,12 @@ There are some specific settings for the controller:
   - Unit: `°C`
   - Default value: `29`
 
-- **Solar min temperature:** The minimum temerature of the heat storage tank which should not be fall below.
+- **Solar min temperature:** The minimum temperature of the heat storage tank, which should not fall below.
 
   - Unit: `°C`
   - Default value: `50`
 
-- **Hysteresis:** Hysteresis in Kelvin which is used to verify if heating should be enabled or disabled to prevent fast toggeling.
+- **Hysteresis:** Hysteresis in Kelvin, which is used to verify if heating should be enabled or disabled to prevent fast toggling.
 
   - Unit: `K`
   - Default value: `1`
@@ -64,13 +64,11 @@ The pump for cleaning and solar heating are enabled/disabled completely manual a
 
 ### Rule: Timer
 
-This rule enables the cleaning pump based on timer settings.
-Solar heating is disabled.
+This rule enables the cleaning pump based on timer settings. Solar heating is disabled.
 
 ### Rule: Auto
 
-This rule enables the cleaning pump based on timer settings.
-Solar heating is enabled **smart** if cleaning pump is enabled by timer and the heat storage tank has enough temperature.
+This rule enables the cleaning pump based on timer settings. Solar heating is enabled **smartly** if the cleaning pump is enabled by timer and the heat storage tank has sufficient temperature.
 
 If the maximum temperature of the pool water is reached, the solar heating is disabled.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -87,7 +87,7 @@ Using Homie 3.0 it is possible to integrate **Smart Pool Controller** directly i
 
 The **Smart Swimmingpool Controller** could be integrated in [openHAB](https://www.openhab.org) since version 2.4.
 
-It is possible to interact with the controller to enable/disable the pump or to swith the current rule.
+It is possible to interact with the controller to enable/disable the pump or to switch the current rule.
 
 Also it is possible to monitor the current values of temperatures or states.
 

--- a/lib/Vector/README.md
+++ b/lib/Vector/README.md
@@ -1,9 +1,9 @@
 
-# Vector: A simple muteable array library for arduino. 
+# Vector: A simple mutable array library for Arduino.
 
-This implementation uses an underlying array to store its elements. When that array is filled the vector allocates a block of memory twice as large as its existing array. It then copies all the existing elements into that array and carries on. For that reason elements substituted as VectorType below need to implement a copy constructor and an operator= to facilitate that transfer if they're to be anything other than POD types.
+This implementation uses an underlying array to store its elements. When that array is filled, the vector allocates a block of memory twice as large as its existing array. It then copies all the existing elements into that array and carries on. For that reason, elements substituted as VectorType below need to implement a copy constructor and an operator= to facilitate that transfer if they're to be anything other than POD types.
 
-To as greater extent as was practical Vector was designed to behave like a std::vector so for more information: http://www.cplusplus.com/reference/vector/vector/ is a good reference. Otherwise, for basic useage check /examples
+To as great an extent as was practical, Vector was designed to behave like a std::vector, so for more information: http://www.cplusplus.com/reference/vector/vector/ is a good reference. Otherwise, for basic usage check /examples
 
 NOTE: This library uses heap memory which can be problematic in microcontrollers where RAM is scarce. If memory availability is an issue then use Reserve(n) to allocate whatever is required at the beginning of the program and avoid pushing more than n elements during the program.
 


### PR DESCRIPTION
## Summary

- Fixed typos: swmming → swimming, comfortable → comfortably, completely → completely, temperature → temperature, etc.
- Fixed grammar: added missing commas, fixed sentence structure
- Improved wording: 'on the smart way' → 'in a smart way'
- Capitalized proper nouns: Arduino, MQTT

## Files changed

- README.md
- docs/_index.md
- docs/software-guide.md
- docs/users-guide.md
- docs/hardware-guide.md
- lib/Vector/README.md