### PR TITLE
feat: NVS config backup, MQTT error reporting, web UI improvements

### DIFF
--- a/.opencode/skills/deploy/SKILL.md
+++ b/.opencode/skills/deploy/SKILL.md
@@ -26,11 +26,12 @@ keywords:
 
 # Deploy — Pool Controller
 
-Complete deployment workflow for the pool-controller ESP32 firmware: build, serial flash, web filesystem upload, OTA update, and semver release management.
+Complete deployment workflow for the pool-controller ESP32 firmware: build,
+serial flash, web filesystem upload, OTA update, and semver release management.
 
 ## Overview
 
-```
+```text
 ┌─────────────┐    ┌──────────────┐    ┌────────────────┐    ┌─────────────────┐
 │  Pre-flight  │ → │  Build       │ → │  Flash / OTA   │ → │  Verify         │
 │  - lint      │    │  pio run     │    │  serial / ota  │    │  - monitor logs │
@@ -110,13 +111,14 @@ find src/ -name '*.cpp' -o -name '*.hpp' -o -name '*.h' | xargs clang-format --d
 
 Expected output:
 
-```
+```text
 RAM:   [==        ]  15.1% (used 49596 bytes from 327680 bytes)
 Flash: [========  ]  83.7% (used 1096433 bytes from 1310720 bytes)
 ========================= [SUCCESS] Took X seconds =========================
 ```
 
-> **Warning:** If flash usage exceeds ~90%, the firmware may not fit. Consider memory optimization (see `cpp-memory-opt` skill).
+> **Warning:** If flash usage exceeds ~90%, the firmware may not fit. Consider
+> memory optimization (see `cpp-memory-opt` skill).
 
 ## Deploy — Serial Flash
 
@@ -217,7 +219,7 @@ The project uses **release-please** for automated semver releases.
 
 Trigger: Push to `main` branch.
 
-```
+```text
 Commit (Conventional Commits) → [release-please] → Release PR
   → Merge PR → [release-please] → GitHub Release + Tag
   → [Build Firmware] → Upload firmware.bin to Release Assets
@@ -250,7 +252,8 @@ Commit (Conventional Commits) → [release-please] → Release PR
 ]
 ```
 
-Release-please automatically updates `FW_VERSION` in both `platformio.ini` and `src/Version.h` when a new release is created.
+Release-please automatically updates `FW_VERSION` in both `platformio.ini` and
+`src/Version.h` when a new release is created.
 
 ### Manual version bump (without release-please)
 
@@ -279,7 +282,7 @@ git tag -a vX.Y.Z -m "Release vX.Y.Z"
 
 Look for these boot patterns:
 
-```
+```text
 ✓ Pin configuration validated
 ✓ Controller setup completed. Free heap: X B     # Normal boot
 ✓ HA Discovery Device ID set to: pool_controller_...

--- a/.opencode/skills/platformio-env/SKILL.md
+++ b/.opencode/skills/platformio-env/SKILL.md
@@ -22,11 +22,14 @@ keywords:
 
 # PlatformIO Environment — Pool Controller
 
-PlatformIO environment configuration for the ESP32 pool-controller. This skill covers the build system, platform configuration, library management, and environment setup — complementing the `platformio-workflow` skill for operational commands.
+PlatformIO environment configuration for the ESP32 pool-controller. This skill
+covers the build system, platform configuration, library management, and
+environment setup — complementing the `platformio-workflow` skill for
+operational commands.
 
 ## Architecture Overview
 
-```
+```text
 pool-controller/
 ├── platformio.ini          ← Single source of truth for build config
 ├── src/                    ← Source code
@@ -88,6 +91,7 @@ lib_deps =
 ```
 
 **Dependency specification formats**:
+
 | Format | Example | Use Case |
 |--------|---------|----------|
 | `LibName` | `DallasTemperature` | Simplest — takes latest from registry |
@@ -242,7 +246,7 @@ Define macros in code with:
 
 After running `pio run`, dependencies are downloaded to:
 
-```
+```text
 .pio/libdeps/esp32dev/
 ├── ArduinoJson/
 ├── Bounce2/
@@ -317,7 +321,7 @@ deactivate
 
 ### Global PlatformIO State
 
-```
+```text
 ~/.platformio/
 ├── platforms/        # Installed platform packages (espressif32, etc.)
 ├── packages/         # Toolchains, frameworks (toolchain-xtensa-esp32, etc.)
@@ -373,11 +377,11 @@ Two workflows reference PlatformIO:
 
 **`.github/workflows/linter.yml`**: Super-Linter runs cpplint separately.
 
-### GitLab CI (`.gitlab-ci.yml`):
+### GitLab CI (`.gitlab-ci.yml`)
 
 Mirror of the same build process for self-hosted runners.
 
-### Travis CI (`.travis-ci.yml`):
+### Travis CI (`.travis-ci.yml`)
 
 Legacy — may no longer be active.
 

--- a/.opencode/skills/platformio-workflow/SKILL.md
+++ b/.opencode/skills/platformio-workflow/SKILL.md
@@ -20,7 +20,9 @@ keywords:
 
 Build, flash, monitor, and OTA operations for the ESP32 pool-controller.
 
-> **🔍 Code Search**: Use `semble search "pio run"` or `semble search "upload_protocol"` to find build-related patterns. See `Agents.md` §7 for full `semble` usage.
+> **🔍 Code Search**: Use `semble search "pio run"` or
+> `semble search "upload_protocol"` to find build-related patterns. See
+> `Agents.md` §7 for full `semble` usage.
 
 ## Environment
 
@@ -98,7 +100,7 @@ pio run --target upload --upload-port 192.168.1.100
 
 ## Project Structure for PlatformIO
 
-```
+```text
 pool-controller/
 ├── platformio.ini       # Build configuration
 ├── src/                 # Source files
@@ -118,7 +120,7 @@ pool-controller/
 
 When monitoring, look for these key patterns:
 
-```
+```text
 ✓ Controller setup completed. Free heap: X B     # Normal boot
 → Boot counter: N                                 # Boot counter (see SystemMonitor)
 ✖ BOOT-LOOP DETECTED                              # Safe mode activated (P8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,31 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- change default MQTT protocol to HomeAssistant ([5d4cad9](https://github.com/smart-swimmingpool/pool-controller/commit/5d4cad9a3173f67e0d3db6c8722207f1e91a8a80))
-- semver release pipeline via release-please (Conventional Commits) ([#29](https://github.com/smart-swimmingpool/pool-controller/issues/29)) ([102b18b](https://github.com/smart-swimmingpool/pool-controller/commit/102b18b64af6364e59147baf462b970cc73e5d7d))
-- **wifi:** add WPS onboarding for initial WiFi provisioning ([#67](https://github.com/smart-swimmingpool/pool-controller/issues/67)) ([6983af6](https://github.com/smart-swimmingpool/pool-controller/commit/6983af6f68110b1e38e286d5c28fdcc1becb5496))
+- change default MQTT protocol to HomeAssistant
+  ([5d4cad9](https://github.com/smart-swimmingpool/pool-controller/commit/5d4cad9a3173f67e0d3db6c8722207f1e91a8a80))
+- semver release pipeline via release-please (Conventional Commits)
+  ([#29](https://github.com/smart-swimmingpool/pool-controller/issues/29))
+  ([102b18b](https://github.com/smart-swimmingpool/pool-controller/commit/102b18b64af6364e59147baf462b970cc73e5d7d))
+- **wifi:** add WPS onboarding for initial WiFi provisioning
+  ([#67](https://github.com/smart-swimmingpool/pool-controller/issues/67))
+  ([6983af6](https://github.com/smart-swimmingpool/pool-controller/commit/6983af6f68110b1e38e286d5c28fdcc1becb5496))
 
 ### Bug Fixes
 
-- **ci:** make website dispatch workflow non-blocking on token issues ([#69](https://github.com/smart-swimmingpool/pool-controller/issues/69)) ([4e03bd3](https://github.com/smart-swimmingpool/pool-controller/commit/4e03bd3a1e0eb71b7c3538e60a5da05d03a1a35a))
-- ESP32 compatibility, memory & buffer fixes + AGENTS.md update ([#68](https://github.com/smart-swimmingpool/pool-controller/issues/68)) ([b95efbd](https://github.com/smart-swimmingpool/pool-controller/commit/b95efbdbd946c99142c5f688a13c1bf77aa1e7db))
-- improve English grammar and word choice in documentation ([#47](https://github.com/smart-swimmingpool/pool-controller/issues/47)) ([2d71dcd](https://github.com/smart-swimmingpool/pool-controller/commit/2d71dcdf5081f0650fa1ad05ce9b447d95806c41))
-- master Branch renamed to main ([f0d0223](https://github.com/smart-swimmingpool/pool-controller/commit/f0d0223ab34884d903e8ef541ae24fc02328faf6))
-- Remove space between platform name and version specifier in nodemcuv2 environment ([0f34a68](https://github.com/smart-swimmingpool/pool-controller/commit/0f34a689038d78021b88aba3c528cf8c66bdd17c))
+- **ci:** make website dispatch workflow non-blocking on token issues
+  ([#69](https://github.com/smart-swimmingpool/pool-controller/issues/69))
+  ([4e03bd3](https://github.com/smart-swimmingpool/pool-controller/commit/4e03bd3a1e0eb71b7c3538e60a5da05d03a1a35a))
+- ESP32 compatibility, memory & buffer fixes + AGENTS.md update
+  ([#68](https://github.com/smart-swimmingpool/pool-controller/issues/68))
+  ([b95efbd](https://github.com/smart-swimmingpool/pool-controller/commit/b95efbdbd946c99142c5f688a13c1bf77aa1e7db))
+- improve English grammar and word choice in documentation
+  ([#47](https://github.com/smart-swimmingpool/pool-controller/issues/47))
+  ([2d71dcd](https://github.com/smart-swimmingpool/pool-controller/commit/2d71dcdf5081f0650fa1ad05ce9b447d95806c41))
+- master Branch renamed to main
+  ([f0d0223](https://github.com/smart-swimmingpool/pool-controller/commit/f0d0223ab34884d903e8ef541ae24fc02328faf6))
+- Remove space between platform name and version specifier in nodemcuv2
+  environment
+  ([0f34a68](https://github.com/smart-swimmingpool/pool-controller/commit/0f34a689038d78021b88aba3c528cf8c66bdd17c))
 
 ## [3.1.0] - 2026-01-14
 

--- a/docs/software-guide.md
+++ b/docs/software-guide.md
@@ -125,18 +125,18 @@ settings survive reboots and power failures:
 
 ### Data Flow on Settings Changes
 
-```
-Web UI / REST API          MQTT (Home Assistant)
-       │                          │
-       ▼                          ▼
-───────┴──── ConfigManager ───────┴────
-              save() → /config.json (LittleFS)
-              ↓
-       OperationModeNode
-       (runtime parameters)
-              ↓
-       MqttPublisher::publishStates()
-       → MQTT topics → Home Assistant
+```text
+Web UI / REST API            MQTT (Home Assistant)
+        │                            │
+        ▼                            ▼
+────────┴────── ConfigManager ───────┴────
+                save() → /config.json (LittleFS)
+                ↓
+        OperationModeNode
+        (runtime parameters)
+                ↓
+        MqttPublisher::publishStates()
+        → MQTT topics → Home Assistant
 ```
 
 > **Note:** When settings are changed via the Web UI, Home Assistant is updated
@@ -150,7 +150,7 @@ Web UI / REST API          MQTT (Home Assistant)
 The controller uses **Home Assistant MQTT Discovery** (default) with topic
 structure:
 
-```
+```text
 homeassistant/<component>/pool-controller/<object-id>/config  (discovery)
 homeassistant/<component>/pool-controller/<object-id>/state   (state)
 homeassistant/<component>/pool-controller/<object-id>/set     (command)
@@ -163,7 +163,11 @@ See `docs/mqtt-configuration.md` for a complete entity mapping.
 If you need to clear retained MQTT messages:
 
 ```bash
+# Clear a specific Home Assistant topic
 mosquitto_pub -h hostname -t "homeassistant/sensor/pool-controller/pool-temp/state" -n -r
+
+# Clear a Homie topic
+mosquitto_pub -h hostname -t homie -n -r -d
 ```
 
 ## Configuration
@@ -197,16 +201,4 @@ How to upload JSON config files see [Homie documentation](https://homieiot.githu
 }
 ```
 
-## MQTT Communication
-
-### Clearing retained messages
-
-In some cases, retained messages may be desired and we don’t want to clear all the retained messages.
-
-The messages will have to be cleared one by one using the topic
-
-To clear a specific message:
-
-```bash
-mosquitto_pub -h hostname -t homie -n -r -d
-```
+<!-- (duplicate MQTT Communication heading removed — content already covered above) -->

--- a/docs/state-persistence.md
+++ b/docs/state-persistence.md
@@ -228,11 +228,11 @@ If the controller reboots frequently:
 1. **Check memory usage**: Review logs for low memory warnings
 2. **Identify memory leak**: Look for pattern in when reboots occur
 3. **Reduce memory usage**:
-   - Increase measurement intervals
-   - Reduce MQTT message frequency
-   - Disable features if possible
+  - Increase measurement intervals
+  - Reduce MQTT message frequency
+  - Disable features if possible
 4. **Lower threshold**: Temporarily lower critical threshold to prevent reboots
-   while debugging
+  while debugging
 
 ### Watchdog Timeouts
 
@@ -241,7 +241,7 @@ If watchdog triggers (ESP32):
 1. **Long-blocking operations**: Check for delays or long operations in code
 2. **Increase timeout**: Modify timeout in `SystemMonitor::begin()`
 3. **Feed more frequently**: Add `SystemMonitor::feedWatchdog()` in long
-   operations
+  operations
 
 ## Technical Details
 

--- a/docs/state-persistence.md
+++ b/docs/state-persistence.md
@@ -228,11 +228,13 @@ If the controller reboots frequently:
 1. **Check memory usage**: Review logs for low memory warnings
 2. **Identify memory leak**: Look for pattern in when reboots occur
 3. **Reduce memory usage**:
-  - Increase measurement intervals
-  - Reduce MQTT message frequency
-  - Disable features if possible
+
+    - Increase measurement intervals
+    - Reduce MQTT message frequency
+    - Disable features if possible
 4. **Lower threshold**: Temporarily lower critical threshold to prevent reboots
-  while debugging
+
+    (the controller will still reboot, but you may extend uptime while debugging)
 
 ### Watchdog Timeouts
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -50,9 +50,11 @@ Once connected, find the controller's IP:
 
 - Check your router's DHCP client list
 - Or use a network scanner like `nmap`:
+
   ```bash
   nmap -p 80 192.168.1.0/24  # scan your subnet for open port 80
   ```
+
 - The web interface shows the assigned IP in the dashboard header
 
 ## Booting Controller
@@ -79,12 +81,14 @@ The controller provides a modern web dashboard at `http://<controller-ip>/` with
 1. Login with your admin password (default: `admin`)
 2. Navigate to the **Configuration** tab
 3. Adjust settings as needed:
-  - **Operation Mode**: Automatic (Solar), Manual Control, Boost Pump, Timer Schedule
-  - **Max Pool Temp**: Target water temperature (°C)
-  - **Min Solar Temp**: Minimum solar collector temperature (°C)
-  - **Temperature Hysteresis**: Deadband to prevent rapid toggling (K)
-  - **Loop Interval**: How often the controller evaluates rules (seconds)
-  - **Timezone**: Select from 10 supported timezones with DST handling
+
+    - **Operation Mode**: Automatic (Solar), Manual Control, Boost Pump, Timer Schedule
+    - **Max Pool Temp**: Target water temperature (°C)
+    - **Min Solar Temp**: Minimum solar collector temperature (°C)
+    - **Temperature Hysteresis**: Deadband to prevent rapid toggling (K)
+    - **Loop Interval**: How often the controller evaluates rules (seconds)
+    - **Timezone**: Select from 10 supported timezones with DST handling
+
 4. Click **Save parameters** — changes are **immediately active** and **persist across reboots**
 5. If MQTT/Home Assistant is connected, the new values are automatically published
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -79,12 +79,12 @@ The controller provides a modern web dashboard at `http://<controller-ip>/` with
 1. Login with your admin password (default: `admin`)
 2. Navigate to the **Configuration** tab
 3. Adjust settings as needed:
-   - **Operation Mode**: Automatic (Solar), Manual Control, Boost Pump, Timer Schedule
-   - **Max Pool Temp**: Target water temperature (°C)
-   - **Min Solar Temp**: Minimum solar collector temperature (°C)
-   - **Temperature Hysteresis**: Deadband to prevent rapid toggling (K)
-   - **Loop Interval**: How often the controller evaluates rules (seconds)
-   - **Timezone**: Select from 10 supported timezones with DST handling
+  - **Operation Mode**: Automatic (Solar), Manual Control, Boost Pump, Timer Schedule
+  - **Max Pool Temp**: Target water temperature (°C)
+  - **Min Solar Temp**: Minimum solar collector temperature (°C)
+  - **Temperature Hysteresis**: Deadband to prevent rapid toggling (K)
+  - **Loop Interval**: How often the controller evaluates rules (seconds)
+  - **Timezone**: Select from 10 supported timezones with DST handling
 4. Click **Save parameters** — changes are **immediately active** and **persist across reboots**
 5. If MQTT/Home Assistant is connected, the new values are automatically published
 


### PR DESCRIPTION
## NVS Config Backup (überlebt uploadfs)

Die device-config wird jetzt automatisch nach NVS gespiegelt (Namespace config-nvs, Key json). Bei jedem ConfigManager::save() wird zusätzlich zu config.json eine Kopie in NVS geschrieben.

Boot-Recovery (4-stufig):
config.json -> OTA Backup (.ota) -> NVS Restore -> Factory Defaults

Damit überlebt die Konfiguration auch ein uploadfs (LittleFS-Komplettlöschung). WiFi-Zugangsdaten, MQTT-Broker, Admin-Passwort und alle Betriebsparameter bleiben erhalten.

### Nötig für bestehende Geräte
Einmal save() triggern (WebUI oder API) nach dem Flashen, damit die NVS-Backup befüllt wird.

---

## MQTT Error Reporting

- NetworkManager tracked jetzt den letzten MQTT-Fehlercode
- REST API /api/status liefert Fehlercode und deutschen Fehlertext
- Fehlerursachen: Zeitüberschreitung, falsche Zugangsdaten, Server nicht erreichbar

## Web UI

- Dashboard: MQTT-Status in der Telemetrie-Leiste
- MQTT-Tab: Detail-Widget mit Verbindungsstatus und Fehlertext
- WiFi-Abhängigkeits-Hinweis für MQTT

## Infrastructure & Docs

- platformio.ini: --no-stub upload_flags für stabileres Flashen
- upload_speed auf 115200
- state-persistence.md: Neuer Abschnitt NVS Config Backup
- software-guide.md: Config-Persistence auf 3 Lagen erweitert
- CHANGELOG.md, README.md, Skills aktualisiert