### PR TITLE
feat: NTP server config via Web UI + MQTT, local time display

### DIFF
--- a/data/web/app.js
+++ b/data/web/app.js
@@ -80,6 +80,23 @@ async function loadTelemetry() {
       document.getElementById('fwVersionDisplay').textContent = data.fw_version;
     }
 
+    // Lokale Uhrzeit
+    if (data.local_time) {
+      const parts = data.local_time.split(' ');
+      document.getElementById('localTimeDisplay').textContent = parts[1] || data.local_time;
+      document.getElementById('localTimeDate').textContent = parts[0] || '';
+      document.getElementById('localTimeZone').textContent = data.timezone_name || '';
+      // Farbpunkt basierend auf Zeit-Sync-Status
+      const dot = document.getElementById('timeDegradationDot');
+      if (data.time_degradation === 0) {
+        dot.style.background = '#22c55e';
+      } else if (data.time_degradation === 1) {
+        dot.style.background = '#eab308';
+      } else {
+        dot.style.background = '#ef4444';
+      }
+    }
+
     // Telemetrie (klein, unten)
     if (data.free_heap != null) {
       document.getElementById('heapVal').textContent = (data.free_heap / 1024).toFixed(0) + ' KB';
@@ -327,11 +344,12 @@ async function saveControllerSettings() {
   const tz = document.getElementById('timezone').value;
   const green = document.getElementById('timeLossGreen').value;
   const red = document.getElementById('timeLossRed').value;
+  const ntpServer = encodeURIComponent(document.getElementById('ntpServer').value);
 
   const res = await fetch('/api/config', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: 'type=settings&mode=' + mode + '&interval=' + interval + '&max_pool=' + maxPool + '&min_solar=' + minSolar + '&hysteresis=' + hysteresis + '&timezone=' + tz + '&green=' + green + '&red=' + red + timerParams()
+    body: 'type=settings&mode=' + mode + '&interval=' + interval + '&max_pool=' + maxPool + '&min_solar=' + minSolar + '&hysteresis=' + hysteresis + '&timezone=' + tz + '&green=' + green + '&red=' + red + timerParams() + '&ntp_server=' + ntpServer
   });
   if (res.status === 200) {
     document.getElementById('poolThreshold').textContent = 'max ' + parseFloat(maxPool).toFixed(1) + '°C';
@@ -394,6 +412,7 @@ async function loadConfig() {
     document.getElementById('tempMinSolar').value = data.settings.temp_min_solar;
     document.getElementById('tempHysteresis').value = data.settings.temp_hysteresis;
     document.getElementById('timezone').value = data.settings.timezone;
+    document.getElementById('ntpServer').value = data.ntp.server;
     document.getElementById('timeLossGreen').value = data.settings.time_loss_green_hours;
     document.getElementById('timeLossRed').value = data.settings.time_loss_red_hours;
     const pad2 = (n) => n.toString().padStart(2, '0');

--- a/data/web/index.html
+++ b/data/web/index.html
@@ -85,6 +85,16 @@
       <div id="modeFeedback" class="mode-feedback" style="display: none; margin-top: 0.5rem; padding: 0.4rem; border-radius: 6px; text-align: center; font-size: 0.8rem;"></div>
     </div>
 
+    <!-- Lokale Uhrzeit -->
+    <div style="background: var(--glass-bg); padding: 0.75rem 1rem; border-radius: 10px; border: 1px solid var(--panel-border); text-align: center;">
+      <div style="display: flex; align-items: center; justify-content: center; gap: 0.5rem;">
+        <span id="timeDegradationDot" style="display: inline-block; width: 10px; height: 10px; border-radius: 50%; background: var(--text-muted);"></span>
+        <span id="localTimeDisplay" style="font-size: 1.2rem; font-weight: 700; font-variant-numeric: tabular-nums;">--:--:--</span>
+      </div>
+      <div id="localTimeDate" style="font-size: 0.75rem; color: var(--text-muted); margin-top: 0.15rem;">----</div>
+      <div id="localTimeZone" style="font-size: 0.7rem; color: var(--text-muted); margin-top: 0.05rem;">---</div>
+    </div>
+
     <!-- Telemetrie (klein, ganz unten) -->
     <div class="telemetry-grid-bottom" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; font-size: 0.7rem; margin-top: 0.5rem; padding-top: 0.75rem; border-top: 1px solid rgba(255,255,255,0.08);">
       <div style="text-align: center;">
@@ -197,7 +207,15 @@
         <option value="4">US Central Time</option>
         <option value="5">US Mountain Time</option>
         <option value="6">US Pacific Time</option>
+        <option value="7">Australian Eastern</option>
+        <option value="8">Japan (JST)</option>
+        <option value="9">China (CST)</option>
       </select>
+    </div>
+    <div class="input-group">
+      <label for="ntpServer">NTP Server</label>
+      <input type="text" id="ntpServer" placeholder="pool.ntp.org">
+      <span class="input-hint">NTP time server for clock sync · Default: pool.ntp.org</span>
     </div>
   </div>
   <div class="telemetry-grid">

--- a/data/web/style.css
+++ b/data/web/style.css
@@ -68,7 +68,7 @@ label {
   color: var(--text-muted);
   margin-bottom: 0.5rem;
 }
-input[type="text"], input[type="password"], input[type="number"], select {
+input[type="text"], input[type="password"], input[type="number"], input[type="time"], input[type="date"], select {
   width: 100%;
   padding: 0.75rem 1rem;
   background: rgba(0, 0, 0, 0.3);

--- a/src/MqttPublisher.cpp
+++ b/src/MqttPublisher.cpp
@@ -9,6 +9,7 @@
 #include "ESP32TemperatureNode.hpp"
 #include "RelayModuleNode.hpp"
 #include "OperationModeNode.hpp"
+#include "TimeClientHelper.hpp"
 #include <ArduinoJson.h>
 
 namespace PoolController {
@@ -169,6 +170,31 @@ void MqttPublisher::publishNumberDiscovery(
   NetworkManager::publish(configTopic.c_str(), payload.c_str(), true);
 }
 
+void MqttPublisher::publishTextDiscovery(const char *objectId, const char *name, const char *icon) {
+  String configTopic = getBaseTopic("text", objectId) + "/config";
+
+  JsonDocument doc;
+  doc["name"] = name;
+  doc["unique_id"] = deviceId_ + "_" + objectId;
+  doc["state_topic"] = getBaseTopic("text", objectId) + "/state";
+  doc["command_topic"] = getBaseTopic("text", objectId) + "/set";
+  doc["availability_topic"] = "homeassistant/sensor/pool-controller/availability";
+  doc["entity_category"] = "config";
+
+  if (icon)
+    doc["icon"] = icon;
+  JsonObject deviceObj = doc["device"].to<JsonObject>();
+  deviceObj["identifiers"][0] = deviceId_;
+  deviceObj["name"] = "Pool Controller";
+  deviceObj["manufacturer"] = "smart-swimmingpool";
+  deviceObj["model"] = "Pool Controller";
+  deviceObj["sw_version"] = FW_VERSION;
+
+  String payload;
+  serializeJson(doc, payload);
+  NetworkManager::publish(configTopic.c_str(), payload.c_str(), true);
+}
+
 void MqttPublisher::publishUpdateDiscovery() {
   String configTopic = getBaseTopic("update", "firmware-update") + "/config";
 
@@ -244,6 +270,7 @@ void MqttPublisher::publishDiscovery() {
   publishSensorDiscovery("max-alloc", "Max Alloc Block", nullptr, "B", "mdi:memory");
   publishSensorDiscovery("rssi", "WiFi Signal Strength", nullptr, "dBm", "mdi:wifi");
   publishSensorDiscovery("uptime", "System Uptime", nullptr, "s", "mdi:clock-outline");
+  publishSensorDiscovery("local-time", "Local Time", nullptr, nullptr, "mdi:clock");
 
   // Relays (Switches)
   publishSwitchDiscovery("pool-pump", "Pool Pump", "mdi:pump");
@@ -262,6 +289,7 @@ void MqttPublisher::publishDiscovery() {
   publishNumberDiscovery("timer-end-h", "Timer End Hour", 0.0, 23.0, 1.0, "h", "mdi:clock-end");
   publishNumberDiscovery("timer-end-min", "Timer End Minute", 0.0, 59.0, 1.0, "min", "mdi:clock-end");
   publishNumberDiscovery("timezone", "Timezone Index", 0.0, 9.0, 1.0, nullptr, "mdi:map-clock");
+  publishTextDiscovery("ntp-server", "NTP Server", "mdi:clock-outline");
 
   // Firmware Update entity
   publishUpdateDiscovery();
@@ -278,6 +306,7 @@ void MqttPublisher::publishDiscovery() {
   NetworkManager::subscribe("homeassistant/number/pool-controller/timer-end-h/set");
   NetworkManager::subscribe("homeassistant/number/pool-controller/timer-end-min/set");
   NetworkManager::subscribe("homeassistant/number/pool-controller/timezone/set");
+  NetworkManager::subscribe("homeassistant/text/pool-controller/ntp-server/set");
   NetworkManager::subscribe("homeassistant/update/pool-controller/firmware-update/set");
 
   Serial.println("✓ HA Discovery Payloads & Subscriptions complete");
@@ -301,6 +330,17 @@ void MqttPublisher::publishStates() {
   NetworkManager::publish(
     (getBaseTopic("sensor", "rssi") + "/state").c_str(), String(NetworkManager::getWiFiRSSI()).c_str(), true);
   NetworkManager::publish((getBaseTopic("sensor", "uptime") + "/state").c_str(), String(millis() / 1000).c_str(), true);
+
+  // Local time state
+  {
+    TimeChangeRule *tcr;
+    time_t localTime = getTimeFor(ConfigManager::getSettings().timezoneIndex, &tcr);
+    char timeBuf[64];
+    snprintf(timeBuf, sizeof(timeBuf), "%04d-%02d-%02d %02d:%02d:%02d",
+      year(localTime), month(localTime), day(localTime),
+      hour(localTime), minute(localTime), second(localTime));
+    NetworkManager::publish((getBaseTopic("sensor", "local-time") + "/state").c_str(), timeBuf, true);
+  }
 
   // Switch States
   NetworkManager::publish(
@@ -328,6 +368,8 @@ void MqttPublisher::publishStates() {
   NetworkManager::publish((getBaseTopic("number", "timer-end-min") + "/state").c_str(), String(ts.timerEndMinutes).c_str(), true);
   NetworkManager::publish(
     (getBaseTopic("number", "timezone") + "/state").c_str(), String(ConfigManager::getSettings().timezoneIndex).c_str(), true);
+  NetworkManager::publish(
+    (getBaseTopic("text", "ntp-server") + "/state").c_str(), ConfigManager::getNtp().server.c_str(), true);
 }
 
 void MqttPublisher::handleMqttMessage(char *topic, uint8_t *payload, unsigned int length) {
@@ -413,6 +455,13 @@ void MqttPublisher::handleMqttMessage(char *topic, uint8_t *payload, unsigned in
     ConfigManager::save();
     // Apply timezone change to running clock immediately (P2 review fix)
     setTimezoneIndex(val);
+  } else if (top.endsWith("/ntp-server/set")) {
+    if (value.length() > 0 && value.length() < 128) {
+      ConfigManager::getNtp().server = value;
+      ConfigManager::save();
+      // Restart NTP client with new server immediately
+      timeClientSetup(ConfigManager::getNtp().server.c_str());
+    }
   }
 
   // Refresh states to confirm changes to Home Assistant

--- a/src/MqttPublisher.hpp
+++ b/src/MqttPublisher.hpp
@@ -16,6 +16,7 @@ public:
   static void handleMqttMessage(char *topic, uint8_t *payload, unsigned int length);
 
 private:
+  static void publishTextDiscovery(const char *objectId, const char *name, const char *icon = nullptr);
   static void publishSensorDiscovery(const char *objectId, const char *name, const char *deviceClass = nullptr,
     const char *unit = nullptr, const char *icon = nullptr);
   static void publishSwitchDiscovery(const char *objectId, const char *name, const char *icon = nullptr);

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -335,6 +335,18 @@ void WebPortal::apiGetStatus() {
   doc["local_ip"] = NetworkManager::getLocalIP();
   doc["fw_version"] = FW_VERSION;
 
+  // Current date/time in configured timezone
+  TimeChangeRule *tcr;
+  time_t localTime = getTimeFor(ConfigManager::getSettings().timezoneIndex, &tcr);
+  char timeBuf[64];
+  snprintf(timeBuf, sizeof(timeBuf), "%04d-%02d-%02d %02d:%02d:%02d",
+    year(localTime), month(localTime), day(localTime),
+    hour(localTime), minute(localTime), second(localTime));
+  doc["local_time"] = timeBuf;
+  doc["local_time_epoch"] = static_cast<long>(localTime);
+  doc["timezone_name"] = getTimeInfoFor(ConfigManager::getSettings().timezoneIndex);
+  doc["time_degradation"] = static_cast<int>(getTimeDegradation());
+
   String json;
   serializeJson(doc, json);
   server_.send(200, "application/json", json);
@@ -368,6 +380,9 @@ void WebPortal::apiGetConfig() {
   mqttObj["port"] = ConfigManager::getMqtt().port;
   mqttObj["username"] = ConfigManager::getMqtt().username;
   mqttObj["use_tls"] = ConfigManager::getMqtt().useTls;
+
+  JsonObject ntpObj = doc["ntp"].to<JsonObject>();
+  ntpObj["server"] = ConfigManager::getNtp().server;
 
   JsonObject settingsObj = doc["settings"].to<JsonObject>();
   settingsObj["op_mode"] = ConfigManager::getSettings().opMode;
@@ -454,6 +469,13 @@ void WebPortal::apiSaveConfig() {
     operationModeNode.setPoolMaxTemperature(ConfigManager::getSettings().tempMaxPool);
     operationModeNode.setSolarMinTemperature(ConfigManager::getSettings().tempMinSolar);
     operationModeNode.setTemperatureHysteresis(ConfigManager::getSettings().tempHysteresis);
+
+    // NTP server live update
+    if (server_.hasArg("ntp_server")) {
+      ConfigManager::getNtp().server = server_.arg("ntp_server");
+      ConfigManager::save();
+      timeClientSetup(ConfigManager::getNtp().server.c_str());
+    }
 
     // Apply timer settings
     {


### PR DESCRIPTION
## Änderungen

### NTP-Server Konfiguration
- **Web UI**: Neues Textfeld `NTP Server` im Settings-Tab (unter Timezone)
- **MQTT/HA**: Text-Entity `ntp-server` via Home Assistant Discovery (setzbar)
- **Live-Update**: NTP-Client wird bei Änderung sofort neu gestartet
- **REST API**: `/api/config` gibt `ntp.server` aus und speichert `ntp_server`

### Lokale Uhrzeit im Dashboard
- Uhrzeit-Karte zwischen Modus-Auswahl und Telemetrie
- Anzeige von: Time-Sync-Status (🟢🟡🔴), Uhrzeit `HH:MM:SS`, Datum, Zeitzonenname
- Neue Felder in `/api/status`: `local_time`, `local_time_epoch`, `timezone_name`, `time_degradation`
- HA-Sensor `local-time` für Kontrollanzeige

### Kleinere Fixes
- Fehlende Zeitzonen-Optionen ergänzt (Australian Eastern, Japan, China)
- `input[type="time"]` und `input[type="date"]` Dark-Theme-Styling