### PR TITLE
feat(web): temperature-based circulation parameters in Web UI

### DIFF
--- a/data/web/app.js
+++ b/data/web/app.js
@@ -110,6 +110,11 @@ async function loadTelemetry() {
       document.getElementById('uptimeVal').textContent = h + 'h ' + m + 'm';
     }
 
+    // Effective Runtime (temperature-based circulation)
+    if (data.effective_runtime != null) {
+      document.getElementById('effectiveRuntimeVal').textContent = data.effective_runtime + ' min';
+    }
+
     // AP-Mode: WiFi-Tab anzeigen
     if (data.ap_mode) {
       switchTab('wifi');
@@ -307,6 +312,9 @@ function validateSettings() {
     { id: 'tempMaxPool',     name: 'Max Pool Temp',       min: 0,   max: 40,   type: 'float' },
     { id: 'tempMinSolar',    name: 'Min Solar Temp',      min: 0,   max: 90,   type: 'float' },
     { id: 'tempHysteresis',  name: 'Hysteresis',          min: 0,   max: 10,   type: 'float' },
+    { id: 'tempCircThreshold',  name: 'Circ. Temp Threshold',   min: 0,   max: 40,   type: 'float' },
+    { id: 'tempCircFactor',     name: 'Circ. Temp Factor',      min: 0,   max: 120,  type: 'int' },
+    { id: 'tempCircMaxRuntime', name: 'Circ. Max Runtime',      min: 60,  max: 1440, type: 'int' },
   ];
   for (const f of fields) {
     const el = document.getElementById(f.id);
@@ -339,6 +347,9 @@ async function saveControllerSettings() {
   const maxPool = document.getElementById('tempMaxPool').value;
   const minSolar = document.getElementById('tempMinSolar').value;
   const hysteresis = document.getElementById('tempHysteresis').value;
+  const circThreshold = document.getElementById('tempCircThreshold').value;
+  const circFactor = document.getElementById('tempCircFactor').value;
+  const circMaxRuntime = document.getElementById('tempCircMaxRuntime').value;
   const tz = document.getElementById('timezone').value;
 
   // Validate time fields included alongside pool fields
@@ -359,7 +370,7 @@ async function saveControllerSettings() {
   const res = await fetch('/api/config', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: 'type=settings&mode=' + mode + '&interval=' + interval + '&max_pool=' + maxPool + '&min_solar=' + minSolar + '&hysteresis=' + hysteresis + '&timezone=' + tz + '&green=' + green + '&red=' + red + timerParams() + '&ntp_server=' + ntpServer
+    body: 'type=settings&mode=' + mode + '&interval=' + interval + '&max_pool=' + maxPool + '&min_solar=' + minSolar + '&hysteresis=' + hysteresis + '&circ_threshold=' + circThreshold + '&circ_factor=' + circFactor + '&circ_max_runtime=' + circMaxRuntime + '&timezone=' + tz + '&green=' + green + '&red=' + red + timerParams() + '&ntp_server=' + ntpServer
   });
   if (res.status === 200) {
     document.getElementById('poolThreshold').textContent = 'max ' + parseFloat(maxPool).toFixed(1) + '°C';
@@ -460,6 +471,9 @@ async function loadConfig() {
     document.getElementById('tempMaxPool').value = data.settings.temp_max_pool;
     document.getElementById('tempMinSolar').value = data.settings.temp_min_solar;
     document.getElementById('tempHysteresis').value = data.settings.temp_hysteresis;
+    document.getElementById('tempCircThreshold').value = data.settings.temp_circ_threshold;
+    document.getElementById('tempCircFactor').value = data.settings.temp_circ_factor;
+    document.getElementById('tempCircMaxRuntime').value = data.settings.temp_circ_max_runtime;
     document.getElementById('timezone').value = data.settings.timezone;
     document.getElementById('ntpServer').value = data.ntp.server;
     document.getElementById('timeLossGreen').value = data.settings.time_loss_green_hours;

--- a/data/web/index.html
+++ b/data/web/index.html
@@ -97,7 +97,7 @@
     </div>
 
     <!-- Telemetrie (klein, ganz unten) -->
-    <div class="telemetry-grid-bottom" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; font-size: 0.7rem; margin-top: 0.5rem; padding-top: 0.75rem; border-top: 1px solid rgba(255,255,255,0.08);">
+    <div class="telemetry-grid-bottom" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; font-size: 0.7rem; margin-top: 0.5rem; padding-top: 0.75rem; border-top: 1px solid rgba(255,255,255,0.08);">
       <div style="text-align: center;">
         <label style="color: var(--text-muted); display: block;">Heap</label>
         <div id="heapVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">--- KB</div>
@@ -109,6 +109,10 @@
       <div style="text-align: center;">
         <label style="color: var(--text-muted); display: block;">Uptime</label>
         <div id="uptimeVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">---</div>
+      </div>
+      <div style="text-align: center;">
+        <label style="color: var(--text-muted); display: block;">Circ. Runtime</label>
+        <div id="effectiveRuntimeVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">--- min</div>
       </div>
     </div>
   </div>
@@ -201,6 +205,30 @@
       <label for="tempHysteresis">Temp Hysteresis (K)</label>
       <input type="number" id="tempHysteresis" min="0" max="10" step="0.1" value="1.0">
       <span class="input-hint">Prevents rapid pump cycling · Recommended: 1.0 K (±0.1–10 K)</span>
+    </div>
+    <div class="input-group" style="visibility:hidden;">
+      <div style="height:1px;"></div>
+    </div>
+  </div>
+
+  <h2>🌡️ Temperature-Based Circulation</h2>
+  <div class="telemetry-grid">
+    <div class="input-group">
+      <label for="tempCircThreshold">Circ. Temp Threshold (°C)</label>
+      <input type="number" id="tempCircThreshold" min="0" max="40" step="0.5" value="24.0">
+      <span class="input-hint">Pump runtime extends above this temperature · Default: 24 °C</span>
+    </div>
+    <div class="input-group">
+      <label for="tempCircFactor">Circ. Temp Factor (min/°C)</label>
+      <input type="number" id="tempCircFactor" min="0" max="120" step="5" value="30">
+      <span class="input-hint">Extra minutes per °C above threshold · Default: 30 min/°C</span>
+    </div>
+  </div>
+  <div class="telemetry-grid">
+    <div class="input-group">
+      <label for="tempCircMaxRuntime">Circ. Max Runtime (min)</label>
+      <input type="number" id="tempCircMaxRuntime" min="60" max="1440" step="15" value="720">
+      <span class="input-hint">Absolute upper limit for total pump runtime · Default: 720 min (12 h)</span>
     </div>
     <div class="input-group" style="visibility:hidden;">
       <div style="height:1px;"></div>

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -358,6 +358,12 @@ void WebPortal::apiGetStatus() {
   doc["timezone_name"] = getTimeInfoFor(ConfigManager::getSettings().timezoneIndex);
   doc["time_degradation"] = static_cast<int>(getTimeDegradation());
 
+  // Effective runtime (temperature-based circulation)
+  {
+    Rule *active = operationModeNode.getRule();
+    doc["effective_runtime"] = (active != nullptr) ? active->getActiveEndMinutes() : 0;
+  }
+
   String json;
   serializeJson(doc, json);
   server_.send(200, "application/json", json);
@@ -401,6 +407,9 @@ void WebPortal::apiGetConfig() {
   settingsObj["temp_max_pool"] = ConfigManager::getSettings().tempMaxPool;
   settingsObj["temp_min_solar"] = ConfigManager::getSettings().tempMinSolar;
   settingsObj["temp_hysteresis"] = ConfigManager::getSettings().tempHysteresis;
+  settingsObj["temp_circ_threshold"] = ConfigManager::getSettings().tempCircThreshold;
+  settingsObj["temp_circ_factor"] = ConfigManager::getSettings().tempCircFactor;
+  settingsObj["temp_circ_max_runtime"] = ConfigManager::getSettings().tempCircMaxRuntime;
   settingsObj["timezone"] = ConfigManager::getSettings().timezoneIndex;
   settingsObj["time_loss_green_hours"] = ConfigManager::getSettings().timeLossGreenHours;
   settingsObj["time_loss_red_hours"] = ConfigManager::getSettings().timeLossRedHours;
@@ -454,6 +463,9 @@ void WebPortal::apiSaveConfig() {
     ConfigManager::getSettings().tempMaxPool = server_.arg("max_pool").toFloat();
     ConfigManager::getSettings().tempMinSolar = server_.arg("min_solar").toFloat();
     ConfigManager::getSettings().tempHysteresis = server_.arg("hysteresis").toFloat();
+    ConfigManager::getSettings().tempCircThreshold = server_.arg("circ_threshold").toFloat();
+    ConfigManager::getSettings().tempCircFactor = server_.arg("circ_factor").toInt();
+    ConfigManager::getSettings().tempCircMaxRuntime = server_.arg("circ_max_runtime").toInt();
     ConfigManager::getSettings().timezoneIndex = server_.arg("timezone").toInt();
     ConfigManager::getSettings().timeLossGreenHours = server_.arg("green").toInt();
     ConfigManager::getSettings().timeLossRedHours = server_.arg("red").toInt();


### PR DESCRIPTION
## Beschreibung

Erweitert das Web-Interface um die drei Parameter der Temperatur-basierten Pumpenlaufzeitverlängerung.

### Pool-Tab (neue Sektion)
| Parameter | Beschreibung | Default |
|---|---|---|
| Circ. Temp Threshold | Schwelle in °C | 24.0 |
| Circ. Temp Factor | Extra-Minuten pro °C | 30 min/°C |
| Circ. Max Runtime | Absolutes Maximum | 720 min (12h) |

### Dashboard
- Neue Telemetrie **Circ. Runtime** zeigt die berechnete effektive Laufzeit

### Backend
- `GET /api/config` serialisiert die 3 neuen Felder
- `POST /api/config` (type=settings) persistiert sie
- `GET /api/status` liefert `effective_runtime`

### Test
- Build erfolgreich (RAM 15.5%, Flash 87.6%)
- Serial und LittleFS geflasht