### PR TITLE
chore: remove unused DHT sensor library and fix clang-format violations

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ board = esp32dev
 framework = arduino
 build_flags =
   ; FW_VERSION is auto-maintained by release-please — do not edit manually
-	'-D FW_VERSION="3.3.0"'  # x-release-please-version
+  '-D FW_VERSION="3.3.0"'  # x-release-please-version
   '-D GITHUB_REPO="smart-swimmingpool/pool-controller"'
   -D SERIAL_SPEED=${common.serial_speed}
   -std=c++17

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,6 @@ lib_deps =
   Wire
   paulstoffregen/OneWire
   Adafruit Unified Sensor
-  DHT sensor library
   NTPClient @ 3.2.1
   TimeZone @ 1.2.6
   bblanchon/ArduinoJson @ 7.3.2

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -20,7 +20,8 @@ String ConfigManager::adminPasswordHash_ = "";
 bool ConfigManager::configured_ = false;
 
 // Default password is "admin" (SHA-256 hash, not a real secret)
-static constexpr const char *kDefaultPasswordHash = "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918";  // NOLINT(whitespace/line_length) gitleaks:allow
+static constexpr const char *kDefaultPasswordHash =
+  "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918";  // NOLINT(whitespace/line_length) gitleaks:allow
 
 static String hashSha256(const String &input) {
   uint8_t hash[32];
@@ -43,26 +44,26 @@ static String hashSha256(const String &input) {
 // ── NVS Key Names ──
 
 static constexpr const char *kNvsNamespace = "config";
-static constexpr const char *kWifiSsid      = "wifi_ssid";
-static constexpr const char *kWifiPass      = "wifi_pass";
-static constexpr const char *kMqttHost      = "mqtt_host";
-static constexpr const char *kMqttPort      = "mqtt_port";
-static constexpr const char *kMqttUser      = "mqtt_user";
-static constexpr const char *kMqttPass      = "mqtt_pass";
-static constexpr const char *kNtpServer     = "ntp_server";
-static constexpr const char *kNtpTz         = "ntp_tz";
-static constexpr const char *kSetInterval   = "set_interval";
-static constexpr const char *kSetMaxPool    = "set_maxpool";
-static constexpr const char *kSetMinSolar   = "set_minsolar";
-static constexpr const char *kSetHyst       = "set_hyst";
-static constexpr const char *kSetOpMode     = "set_opmode";
-static constexpr const char *kSetTzIdx      = "set_tzidx";
-static constexpr const char *kSetGreen      = "set_green";
-static constexpr const char *kSetRed        = "set_red";
+static constexpr const char *kWifiSsid = "wifi_ssid";
+static constexpr const char *kWifiPass = "wifi_pass";
+static constexpr const char *kMqttHost = "mqtt_host";
+static constexpr const char *kMqttPort = "mqtt_port";
+static constexpr const char *kMqttUser = "mqtt_user";
+static constexpr const char *kMqttPass = "mqtt_pass";
+static constexpr const char *kNtpServer = "ntp_server";
+static constexpr const char *kNtpTz = "ntp_tz";
+static constexpr const char *kSetInterval = "set_interval";
+static constexpr const char *kSetMaxPool = "set_maxpool";
+static constexpr const char *kSetMinSolar = "set_minsolar";
+static constexpr const char *kSetHyst = "set_hyst";
+static constexpr const char *kSetOpMode = "set_opmode";
+static constexpr const char *kSetTzIdx = "set_tzidx";
+static constexpr const char *kSetGreen = "set_green";
+static constexpr const char *kSetRed = "set_red";
 static constexpr const char *kSetCircThresh = "set_circth";
 static constexpr const char *kSetCircFactor = "set_circfa";
-static constexpr const char *kSetCircMax    = "set_circmx";
-static constexpr const char *kAdmPass       = "adm_pass";
+static constexpr const char *kSetCircMax = "set_circmx";
+static constexpr const char *kAdmPass = "adm_pass";
 static constexpr const char *kCfgConfigured = "cfg_configured";
 
 // ── Lifecycle ──
@@ -80,31 +81,31 @@ bool ConfigManager::load() {
     return false;
   }
 
-  wifi_.ssid       = prefs.getString(kWifiSsid, "");
-  wifi_.password   = prefs.getString(kWifiPass, "");
+  wifi_.ssid = prefs.getString(kWifiSsid, "");
+  wifi_.password = prefs.getString(kWifiPass, "");
 
-  mqtt_.host       = prefs.getString(kMqttHost, "");
-  mqtt_.port       = prefs.getUInt(kMqttPort, 1883);
-  mqtt_.username   = prefs.getString(kMqttUser, "");
-  mqtt_.password   = prefs.getString(kMqttPass, "");
+  mqtt_.host = prefs.getString(kMqttHost, "");
+  mqtt_.port = prefs.getUInt(kMqttPort, 1883);
+  mqtt_.username = prefs.getString(kMqttUser, "");
+  mqtt_.password = prefs.getString(kMqttPass, "");
 
-  ntp_.server      = prefs.getString(kNtpServer, "pool.ntp.org");
-  ntp_.timezone    = prefs.getLong(kNtpTz, 0);
+  ntp_.server = prefs.getString(kNtpServer, "pool.ntp.org");
+  ntp_.timezone = prefs.getLong(kNtpTz, 0);
 
-  settings_.loopInterval       = prefs.getLong(kSetInterval, 10);
-  settings_.tempMaxPool        = prefs.getDouble(kSetMaxPool, 28.5);
-  settings_.tempMinSolar       = prefs.getDouble(kSetMinSolar, 55.0);
-  settings_.tempHysteresis     = prefs.getDouble(kSetHyst, 1.0);
-  settings_.opMode             = prefs.getString(kSetOpMode, "auto");
-  settings_.timezoneIndex      = prefs.getInt(kSetTzIdx, 0);
+  settings_.loopInterval = prefs.getLong(kSetInterval, 10);
+  settings_.tempMaxPool = prefs.getDouble(kSetMaxPool, 28.5);
+  settings_.tempMinSolar = prefs.getDouble(kSetMinSolar, 55.0);
+  settings_.tempHysteresis = prefs.getDouble(kSetHyst, 1.0);
+  settings_.opMode = prefs.getString(kSetOpMode, "auto");
+  settings_.timezoneIndex = prefs.getInt(kSetTzIdx, 0);
   settings_.timeLossGreenHours = prefs.getUChar(kSetGreen, 1);
-  settings_.timeLossRedHours   = prefs.getUChar(kSetRed, 24);
-  settings_.tempCircThreshold  = prefs.getDouble(kSetCircThresh, 24.0);
-  settings_.tempCircFactor     = prefs.getUShort(kSetCircFactor, 30);
+  settings_.timeLossRedHours = prefs.getUChar(kSetRed, 24);
+  settings_.tempCircThreshold = prefs.getDouble(kSetCircThresh, 24.0);
+  settings_.tempCircFactor = prefs.getUShort(kSetCircFactor, 30);
   settings_.tempCircMaxRuntime = prefs.getUShort(kSetCircMax, 720);
 
   adminPasswordHash_ = prefs.getString(kAdmPass, kDefaultPasswordHash);
-  configured_        = prefs.getBool(kCfgConfigured, false);
+  configured_ = prefs.getBool(kCfgConfigured, false);
 
   prefs.end();
 

--- a/src/ConfigManager.hpp
+++ b/src/ConfigManager.hpp
@@ -38,8 +38,8 @@ struct ControllerSettings {
   double tempMinSolar = 55.0;
   double tempHysteresis = 1.0;
   double tempCircThreshold = 24.0;    ///< Temperature-based circulation: threshold in °C
-  uint16_t tempCircFactor = 30;        ///< Temperature-based circulation: extra minutes per °C
-  uint16_t tempCircMaxRuntime = 720;   ///< Temperature-based circulation: max total runtime in minutes
+  uint16_t tempCircFactor = 30;       ///< Temperature-based circulation: extra minutes per °C
+  uint16_t tempCircMaxRuntime = 720;  ///< Temperature-based circulation: max total runtime in minutes
   String opMode = "auto";
   long timeLossGreenHours = 1;
   long timeLossRedHours = 24;

--- a/src/MqttPublisher.cpp
+++ b/src/MqttPublisher.cpp
@@ -56,9 +56,8 @@ String MqttPublisher::getBaseTopic(const char *component, const char *objectId) 
   return String("homeassistant/") + component + "/pool-controller/" + objectId;
 }
 
-void MqttPublisher::publishSensorDiscovery(
-  const char *objectId, const char *name, const char *deviceClass, const char *unit, const char *icon,
-  const char *entityCategory) {
+void MqttPublisher::publishSensorDiscovery(const char *objectId, const char *name, const char *deviceClass, const char *unit,
+  const char *icon, const char *entityCategory) {
   String configTopic = getBaseTopic("sensor", objectId) + "/config";
 
   JsonDocument doc;
@@ -89,8 +88,7 @@ void MqttPublisher::publishSensorDiscovery(
   NetworkManager::publish(configTopic.c_str(), payload.c_str(), true);
 }
 
-void MqttPublisher::publishSwitchDiscovery(const char *objectId, const char *name, const char *icon,
-  const char *entityCategory) {
+void MqttPublisher::publishSwitchDiscovery(const char *objectId, const char *name, const char *icon, const char *entityCategory) {
   String configTopic = getBaseTopic("switch", objectId) + "/config";
 
   JsonDocument doc;
@@ -119,9 +117,8 @@ void MqttPublisher::publishSwitchDiscovery(const char *objectId, const char *nam
   NetworkManager::publish(configTopic.c_str(), payload.c_str(), true);
 }
 
-void MqttPublisher::publishSelectDiscovery(
-  const char *objectId, const char *name, const char *const *options, size_t optionCount, const char *icon,
-  const char *entityCategory) {
+void MqttPublisher::publishSelectDiscovery(const char *objectId, const char *name, const char *const *options, size_t optionCount,
+  const char *icon, const char *entityCategory) {
   String configTopic = getBaseTopic("select", objectId) + "/config";
 
   JsonDocument doc;
@@ -153,9 +150,8 @@ void MqttPublisher::publishSelectDiscovery(
   NetworkManager::publish(configTopic.c_str(), payload.c_str(), true);
 }
 
-void MqttPublisher::publishNumberDiscovery(
-  const char *objectId, const char *name, double minVal, double maxVal, double step, const char *unit, const char *icon,
-  const char *entityCategory) {
+void MqttPublisher::publishNumberDiscovery(const char *objectId, const char *name, double minVal, double maxVal, double step,
+  const char *unit, const char *icon, const char *entityCategory) {
   String configTopic = getBaseTopic("number", objectId) + "/config";
 
   JsonDocument doc;
@@ -213,8 +209,7 @@ void MqttPublisher::publishTextDiscovery(const char *objectId, const char *name,
   NetworkManager::publish(configTopic.c_str(), payload.c_str(), true);
 }
 
-void MqttPublisher::publishTimeDiscovery(const char *objectId, const char *name, const char *icon,
-  const char *entityCategory) {
+void MqttPublisher::publishTimeDiscovery(const char *objectId, const char *name, const char *icon, const char *entityCategory) {
   String configTopic = getBaseTopic("time", objectId) + "/config";
 
   JsonDocument doc;
@@ -337,8 +332,7 @@ void MqttPublisher::publishClimateState() {
   } else {
     hvacMode = "off";
   }
-  NetworkManager::publish(
-    (getBaseTopic("climate", "thermostat") + "/mode/state").c_str(), hvacMode, true);
+  NetworkManager::publish((getBaseTopic("climate", "thermostat") + "/mode/state").c_str(), hvacMode, true);
 
   // Action: solar pump ON → heating, pool pump ON → idle, both OFF → off
   const char *action = "off";
@@ -349,8 +343,7 @@ void MqttPublisher::publishClimateState() {
   } else {
     action = "off";
   }
-  NetworkManager::publish(
-    (getBaseTopic("climate", "thermostat") + "/action/state").c_str(), action, true);
+  NetworkManager::publish((getBaseTopic("climate", "thermostat") + "/action/state").c_str(), action, true);
 }
 
 void MqttPublisher::publishUpdateState() {
@@ -422,14 +415,10 @@ void MqttPublisher::publishDiscovery() {
   publishTimeDiscovery("timer-end", "Timer End", "mdi:clock-end");
 
   // Temperature-based circulation parameters (entity_category: "config")
-  publishNumberDiscovery(
-    "temp-circ-threshold", "Circ. Temp Threshold", 0.0, 40.0, 0.5, "°C", "mdi:thermometer-auto", "config");
-  publishNumberDiscovery(
-    "temp-circ-factor", "Circ. Temp Factor", 0.0, 120.0, 5.0, "min/°C", "mdi:plus-minus", "config");
-  publishNumberDiscovery(
-    "temp-circ-max-runtime", "Circ. Max Runtime", 60.0, 1440.0, 15.0, "min", "mdi:timer-outline", "config");
-  publishSensorDiscovery(
-    "effective-runtime", "Effective Runtime", "duration", "s", "mdi:timer-sand", "diagnostic");
+  publishNumberDiscovery("temp-circ-threshold", "Circ. Temp Threshold", 0.0, 40.0, 0.5, "°C", "mdi:thermometer-auto", "config");
+  publishNumberDiscovery("temp-circ-factor", "Circ. Temp Factor", 0.0, 120.0, 5.0, "min/°C", "mdi:plus-minus", "config");
+  publishNumberDiscovery("temp-circ-max-runtime", "Circ. Max Runtime", 60.0, 1440.0, 15.0, "min", "mdi:timer-outline", "config");
+  publishSensorDiscovery("effective-runtime", "Effective Runtime", "duration", "s", "mdi:timer-sand", "diagnostic");
 
   // ── Configuration (entity_category: "config") ──
   publishSelectDiscovery("timezone", "Timezone", getTimezoneLabelList(), getTimezoneLabelCount(), "mdi:map-clock", "config");
@@ -506,8 +495,7 @@ void MqttPublisher::publishStates() {
     TimeChangeRule *tcr;
     time_t localTime = getTimeFor(ConfigManager::getSettings().timezoneIndex, &tcr);
     char timeBuf[64];
-    snprintf(timeBuf, sizeof(timeBuf), "%04d-%02d-%02d %02d:%02d:%02d",
-      year(localTime), month(localTime), day(localTime),
+    snprintf(timeBuf, sizeof(timeBuf), "%04d-%02d-%02d %02d:%02d:%02d", year(localTime), month(localTime), day(localTime),
       hour(localTime), minute(localTime), second(localTime));
     NetworkManager::publish((getBaseTopic("sensor", "local-time") + "/state").c_str(), timeBuf, true);
   }
@@ -559,12 +547,11 @@ void MqttPublisher::publishStates() {
   }
   NetworkManager::publish((getBaseTopic("select", "timezone") + "/state").c_str(),
     getTimeInfoFor(ConfigManager::getSettings().timezoneIndex).c_str(), true);
-  NetworkManager::publish(
-    (getBaseTopic("text", "ntp-server") + "/state").c_str(), ConfigManager::getNtp().server.c_str(), true);
+  NetworkManager::publish((getBaseTopic("text", "ntp-server") + "/state").c_str(), ConfigManager::getNtp().server.c_str(), true);
 }
 
-void MqttPublisher::handleMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties properties,
-  size_t len, size_t index, size_t total) {
+void MqttPublisher::handleMqttMessage(
+  char *topic, char *payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
   // Only process complete messages (single-chunk delivery for typical HA commands)
   if (index != 0) {
     return;

--- a/src/MqttPublisher.hpp
+++ b/src/MqttPublisher.hpp
@@ -38,22 +38,21 @@ public:
    * @param index   Chunk index (0 for single-chunk messages).
    * @param total   Total payload size across all chunks.
    */
-  static void handleMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties properties,
-    size_t len, size_t index, size_t total);
+  static void handleMqttMessage(
+    char *topic, char *payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total);
 
 private:
   static void publishTextDiscovery(const char *objectId, const char *name, const char *icon = nullptr);
   static void publishSensorDiscovery(const char *objectId, const char *name, const char *deviceClass = nullptr,
     const char *unit = nullptr, const char *icon = nullptr, const char *entityCategory = nullptr);
-  static void publishSwitchDiscovery(const char *objectId, const char *name, const char *icon = nullptr,
-    const char *entityCategory = nullptr);
-  static void publishSelectDiscovery(
-    const char *objectId, const char *name, const char *const *options, size_t optionCount, const char *icon = nullptr,
-    const char *entityCategory = nullptr);
+  static void publishSwitchDiscovery(
+    const char *objectId, const char *name, const char *icon = nullptr, const char *entityCategory = nullptr);
+  static void publishSelectDiscovery(const char *objectId, const char *name, const char *const *options, size_t optionCount,
+    const char *icon = nullptr, const char *entityCategory = nullptr);
   static void publishNumberDiscovery(const char *objectId, const char *name, double minVal, double maxVal, double step,
     const char *unit = nullptr, const char *icon = nullptr, const char *entityCategory = nullptr);
-  static void publishTimeDiscovery(const char *objectId, const char *name, const char *icon = nullptr,
-    const char *entityCategory = nullptr);
+  static void publishTimeDiscovery(
+    const char *objectId, const char *name, const char *icon = nullptr, const char *entityCategory = nullptr);
   static void publishUpdateDiscovery();
   static void publishClimateDiscovery();
 

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -46,9 +46,8 @@ bool NetworkManager::begin() {
     // Publish online to LWT topic immediately (async, non-blocking)
     mqttClient_.publish("homeassistant/sensor/pool-controller/availability", 1, true, "online");
   });
-  mqttClient_.onDisconnect([](AsyncMqttClientDisconnectReason reason) {
-    Serial.printf("✖ MQTT disconnected, reason=%d\n", static_cast<int>(reason));
-  });
+  mqttClient_.onDisconnect(
+    [](AsyncMqttClientDisconnectReason reason) { Serial.printf("✖ MQTT disconnected, reason=%d\n", static_cast<int>(reason)); });
 
   if (ConfigManager::getWiFi().ssid.length() == 0) {
     Serial.println("⚠ No WiFi SSID configured! Starting AP mode.");
@@ -104,16 +103,29 @@ void NetworkManager::loop() {
       wl_status_t status = WiFi.status();
       const char *statusStr = "";
       switch (status) {
-      case WL_IDLE_STATUS:     statusStr = "IDLE"; break;
-      case WL_NO_SSID_AVAIL:   statusStr = "NO_SSID_AVAIL"; break;
-      case WL_SCAN_COMPLETED:  statusStr = "SCAN_COMPLETED"; break;
-      case WL_CONNECT_FAILED:  statusStr = "CONNECT_FAILED"; break;
-      case WL_CONNECTION_LOST: statusStr = "CONNECTION_LOST"; break;
-      case WL_DISCONNECTED:    statusStr = "DISCONNECTED"; break;
-      default:                 statusStr = "UNKNOWN"; break;
+      case WL_IDLE_STATUS:
+        statusStr = "IDLE";
+        break;
+      case WL_NO_SSID_AVAIL:
+        statusStr = "NO_SSID_AVAIL";
+        break;
+      case WL_SCAN_COMPLETED:
+        statusStr = "SCAN_COMPLETED";
+        break;
+      case WL_CONNECT_FAILED:
+        statusStr = "CONNECT_FAILED";
+        break;
+      case WL_CONNECTION_LOST:
+        statusStr = "CONNECTION_LOST";
+        break;
+      case WL_DISCONNECTED:
+        statusStr = "DISCONNECTED";
+        break;
+      default:
+        statusStr = "UNKNOWN";
+        break;
       }
-      Serial.printf("🔄 WiFi retry... status=%s (%d), elapsed=%ums\n",
-        statusStr, status, now - connectionStartTime_);
+      Serial.printf("🔄 WiFi retry... status=%s (%d), elapsed=%ums\n", statusStr, status, now - connectionStartTime_);
       connectWiFi();
     }
     return;
@@ -223,9 +235,8 @@ void NetworkManager::disconnectMqtt() {
 void NetworkManager::handleWiFiEvent(WiFiEvent_t event) {
   switch (event) {
   case ARDUINO_EVENT_WIFI_STA_GOT_IP:
-    Serial.printf(
-      "✓ WiFi connected! SSID: \"%s\", IP: %s, RSSI: %d dBm, Channel: %d\n",
-      WiFi.SSID().c_str(), WiFi.localIP().toString().c_str(), WiFi.RSSI(), WiFi.channel());
+    Serial.printf("✓ WiFi connected! SSID: \"%s\", IP: %s, RSSI: %d dBm, Channel: %d\n", WiFi.SSID().c_str(),
+      WiFi.localIP().toString().c_str(), WiFi.RSSI(), WiFi.channel());
     apModeActive_ = false;
     // Start mDNS responder so the device is reachable as pool-controller.local
     if (!mdnsRunning_) {

--- a/src/Rule.hpp
+++ b/src/Rule.hpp
@@ -69,7 +69,7 @@ public:
   uint16_t getEffectiveRuntimeMinutes() const {
     TimerSetting ts = getTimerSetting();
     uint16_t baseStart = ts.timerStartHour * 60 + ts.timerStartMinutes;
-    uint16_t baseEnd   = ts.timerEndHour * 60 + ts.timerEndMinutes;
+    uint16_t baseEnd = ts.timerEndHour * 60 + ts.timerEndMinutes;
 
     // Base runtime (handles midnight crossing)
     uint16_t baseRuntime;
@@ -173,8 +173,8 @@ protected:
       }
 
       if (inExtendedWindow) {
-        Serial.printf("  checkPoolPumpTimer = true (extended to %02d:%02d)\n",
-          (uint8_t)(normalizedEnd / 60), (uint8_t)(normalizedEnd % 60));
+        Serial.printf(
+          "  checkPoolPumpTimer = true (extended to %02d:%02d)\n", (uint8_t)(normalizedEnd / 60), (uint8_t)(normalizedEnd % 60));
         return true;
       }
 

--- a/src/StatusLed.cpp
+++ b/src/StatusLed.cpp
@@ -82,7 +82,7 @@ bool StatusLed::computeDesiredState(const uint32_t nowMs) {
     return true;  // dauerhaft an
 
   case StatusLedPattern::OFF:
-    return false; // dauerhaft aus
+    return false;  // dauerhaft aus
 
   case StatusLedPattern::AP_MODE: {
     // 100ms an / 100ms aus = 5 Hz
@@ -112,8 +112,7 @@ bool StatusLed::computeDesiredState(const uint32_t nowMs) {
     // Doppel-Blink: 200ms an, 200ms aus, 200ms an, 600ms aus
     // Gesamtzyklus: 1200ms
     const uint32_t phase = nowMs % T_SAFE_CYCLE;
-    return (phase < T_SAFE_PHASE1_END) ||
-      (phase >= T_SAFE_PHASE2_END && phase < T_SAFE_PHASE3_END);
+    return (phase < T_SAFE_PHASE1_END) || (phase >= T_SAFE_PHASE2_END && phase < T_SAFE_PHASE3_END);
   }
   }
 

--- a/src/StatusLed.hpp
+++ b/src/StatusLed.hpp
@@ -116,9 +116,9 @@ private:
 
   /// Safe-Mode Doppel-Blink (siehe computeDesiredState)
   static constexpr uint32_t T_SAFE_CYCLE{1200};
-  static constexpr uint32_t T_SAFE_PHASE1_END{200};   // ON 0–200ms
-  static constexpr uint32_t T_SAFE_PHASE2_END{400};   // OFF 200–400ms
-  static constexpr uint32_t T_SAFE_PHASE3_END{600};   // ON 400–600ms
+  static constexpr uint32_t T_SAFE_PHASE1_END{200};  // ON 0–200ms
+  static constexpr uint32_t T_SAFE_PHASE2_END{400};  // OFF 200–400ms
+  static constexpr uint32_t T_SAFE_PHASE3_END{600};  // ON 400–600ms
   // rest 600–1200ms = OFF
 };
 

--- a/src/TimeClientHelper.cpp
+++ b/src/TimeClientHelper.cpp
@@ -66,8 +66,8 @@ TimeZoneInfo _timezones[10] = {{"Central Europe (CET/CEST)", &Europe}, {"Eastern
 
 // Pointer array for MQTT Select / web UI labels — mirrors _timezones descriptions
 static const char *kTzLabels[] = {"Central Europe (CET/CEST)", "Eastern Europe (EET/EEST)", "Western Europe (WET/WEST)",
-  "US Eastern Time", "US Central Time", "US Mountain Time", "US Pacific Time",
-  "Australian Eastern", "Japan (JST)", "China (CST)"};
+  "US Eastern Time", "US Central Time", "US Mountain Time", "US Pacific Time", "Australian Eastern", "Japan (JST)",
+  "China (CST)"};
 static constexpr int kTzLabelCount = sizeof(kTzLabels) / sizeof(kTzLabels[0]);
 
 int _selectedTimezoneIndex = 0;  // Default to Central European Time

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -62,7 +62,7 @@ uint16_t calculateEffectiveEndMinutes(uint16_t baseStartMinutes, uint16_t baseEn
   if (baseEndMinutes >= baseStartMinutes) {
     baseRuntime = baseEndMinutes - baseStartMinutes;
   } else {
-    baseRuntime = (1440 - baseStartMinutes) + baseEndMinutes; // Midnight crossing
+    baseRuntime = (1440 - baseStartMinutes) + baseEndMinutes;  // Midnight crossing
   }
 
   if (baseRuntime == 0) {
@@ -84,9 +84,8 @@ uint16_t calculateEffectiveEndMinutes(uint16_t baseStartMinutes, uint16_t baseEn
   // Calculate new end minutes (add runtime to start, can wrap past midnight)
   uint16_t extended = baseStartMinutes + totalRuntime;
 
-  Serial.printf("  → TempCirc: %.1f°C, base=%umin, extra=%umin, total=%umin, end=%02d:%02d\n",
-    poolTemp, baseRuntime, extra, totalRuntime,
-    (extended / 60) % 24, extended % 60);
+  Serial.printf("  → TempCirc: %.1f°C, base=%umin, extra=%umin, total=%umin, end=%02d:%02d\n", poolTemp, baseRuntime, extra,
+    totalRuntime, (extended / 60) % 24, extended % 60);
 
   return extended;
 }

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -350,8 +350,7 @@ void WebPortal::apiGetStatus() {
   TimeChangeRule *tcr;
   time_t localTime = getTimeFor(ConfigManager::getSettings().timezoneIndex, &tcr);
   char timeBuf[64];
-  snprintf(timeBuf, sizeof(timeBuf), "%04d-%02d-%02d %02d:%02d:%02d",
-    year(localTime), month(localTime), day(localTime),
+  snprintf(timeBuf, sizeof(timeBuf), "%04d-%02d-%02d %02d:%02d:%02d", year(localTime), month(localTime), day(localTime),
     hour(localTime), minute(localTime), second(localTime));
   doc["local_time"] = timeBuf;
   doc["local_time_epoch"] = static_cast<long>(localTime);


### PR DESCRIPTION
## Beschreibung

Zwei Cleanup-Änderungen aus dem Code-Quality-Review:

### 1. Unused Dependency entfernt
`DHT sensor library` wird in keinem Source-File verwendet → aus `platformio.ini` entfernt.

### 2. clang-format auf allen Source-Dateien
11 Dateien hatten Formatierungs-Abweichungen. Einmaliger `clang-format -i`-Run:
- Alignment von Member-Initialisierungen
- Multi-line Parameter-Wrapping
- Switch-Case Einrückungen
- Alignment von Kommentaren

Änderungen sind rein kosmetisch — kein Behavior Change.