### PR TITLE
chore(skill): expand EditorConfig checks to all file types in cpp-code-quality skill

### DIFF
--- a/.opencode/skills/cpp-code-quality/SKILL.md
+++ b/.opencode/skills/cpp-code-quality/SKILL.md
@@ -64,20 +64,40 @@ python3 -m venv /tmp/lint-venv && /tmp/lint-venv/bin/pip install cpplint
 
 ### Gate 3 — EditorConfig Compliance
 
+**Wichtig:** CI prüft per `editorconfig-checker` **alle** Dateien im Repository (`.editorconfig` Rule `[*]`).
+Daher müssen lokale Checks ebenfalls alle Dateitypen abdecken — nicht nur C++ und Web-UI.
+
+#### Variante A (empfohlen): editorconfig-checker
+
 ```bash
-# Check auf Tabs, Trailing Whitespace, fehlende Final Newline
+# Einmalig installieren:
+sudo npm install -g editorconfig-checker
+
+# Prüft alle Dateien gegen .editorconfig:
+editorconfig-checker -exclude '.git|.pio|.vscode|.platformio|build|lib|node_modules'
+```
+
+#### Variante B: Manuelle Checks (alle git-getrackten Textdateien)
+
+```bash
+# Alle git-getrackten Dateien als Grundlage
+FILES=$(git ls-files '*.cpp' '*.hpp' '*.h' '*.html' '*.js' '*.css' \
+  '*.ini' '*.yml' '*.yaml' '*.json' '*.md' '*.cfg' '*.txt' '*.sh' 'Makefile' \
+  '.editorconfig' '.gitignore' '.prettierrc' 'CPPLINT.cfg')
+
 # Keine Tabs:
-find src data/web -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.html" -o -name "*.js" -o -name "*.css" \) \
-  -exec grep -l $'\t' {} \; | grep . && echo "TABS GEFUNDEN!" || echo "✓ Keine Tabs"
+echo "$FILES" | tr ' ' '\n' | xargs grep -l $'\t' 2>/dev/null \
+  | grep . && echo "✗ TABS GEFUNDEN!" || echo "✓ Keine Tabs"
 
 # Kein Trailing Whitespace:
-find src data/web -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.html" -o -name "*.js" -o -name "*.css" \) \
-  -exec grep -l '[[:space:]]$' {} \; | grep . && echo "TRAILING WHITESPACE GEFUNDEN!" || echo "✓ Kein Trailing Whitespace"
+echo "$FILES" | tr ' ' '\n' | xargs grep -l '[[:space:]]$' 2>/dev/null \
+  | grep . && echo "✗ TRAILING WHITESPACE!" || echo "✓ Kein Trailing Whitespace"
 
-# Final Newline (via EditorConfig checker oder manuelle Prüfung):
-for f in $(find src data/web -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.html" -o -name "*.js" -o -name "*.css" \)); do
+# Final Newline:
+echo "$FILES" | tr ' ' '\n' | while IFS= read -r f; do
+  [ -f "$f" ] || continue
   last=$(tail -c 1 "$f")
-  [ -z "$last" ] && echo "✓ $f" || echo "✗ KEINE FINAL NEWLINE: $f"
+  [ -z "$last" ] || echo "✗ KEINE FINAL NEWLINE: $f"
 done | grep "✗" || echo "✓ Alle Dateien haben Final Newline"
 ```
 
@@ -125,7 +145,12 @@ docker run --rm --platform linux/arm64 -v $(pwd):/work -w /work ubuntu:22.04 \
   src/*.cpp src/*.hpp src/Nodes/*.cpp src/Nodes/*.hpp
 
 # 3. EditorConfig
-find src -type f \( -name "*.cpp" -o -name "*.hpp" \) -exec grep -l '[[:space:]]$' {} \; | grep . && echo "TRAILING WHITESPACE!"
+editorconfig-checker -exclude '.git|.pio|.vscode|.platformio|build|lib|node_modules'
+# Fallback: git-getrackte Textdateien manuell prüfen
+FILES=$(git ls-files '*.cpp' '*.hpp' '*.h' '*.html' '*.js' '*.css' \
+  '*.ini' '*.yml' '*.yaml' '*.json' '*.md' '*.cfg' '*.txt' '*.sh' 'Makefile')
+echo "$FILES" | tr ' ' '\n' | xargs grep -l '[[:space:]]$' 2>/dev/null \
+  | grep . && echo "TRAILING WHITESPACE!"
 
 # 4. Static Analysis
 pio check --environment esp32dev --skip-packages
@@ -223,17 +248,20 @@ docker run --rm --platform linux/arm64 -v $(pwd):/work -w /work ubuntu:22.04 \
 - **No trailing whitespace**
 - **Final newline** at end of every file
 
-**Auto-fix**:
+**Auto-fix** (alle git-getrackten Textdateien):
 
 ```bash
-# Remove tabs (C++)
-find src -type f \( -name "*.cpp" -o -name "*.hpp" \) -exec sed -i 's/\t/  /g' {} \;
+# Alle relevanten Dateien finden
+FILES=$(git ls-files '*.cpp' '*.hpp' '*.h' '*.html' '*.js' '*.css' \
+  '*.ini' '*.yml' '*.yaml' '*.json' '*.md' '*.cfg' '*.txt' '*.sh' 'Makefile' \
+  '.editorconfig' '.gitignore' 'CPPLINT.cfg')
 
-# Remove trailing whitespace (C++)
-find src -type f \( -name "*.cpp" -o -name "*.hpp" \) -exec sed -i 's/[[:space:]]*$//' {} \;
+# Remove tabs → spaces (Vorsicht: Makefile erlaubt Tabs!)
+echo "$FILES" | tr ' ' '\n' | grep -v '^Makefile$' | \
+  xargs sed -i 's/\t/  /g' 2>/dev/null || true
 
-# Remove trailing whitespace (Web UI)
-find data/web -type f \( -name "*.html" -o -name "*.js" -o -name "*.css" \) -exec sed -i 's/[[:space:]]*$//' {} \;
+# Remove trailing whitespace
+echo "$FILES" | tr ' ' '\n' | xargs sed -i 's/[[:space:]]*$//' 2>/dev/null || true
 ```
 
 ### 3. Cpplint Include Order
@@ -322,6 +350,10 @@ ln -s ../../scripts/pre-commit.sh .git/hooks/pre-commit
 ```
 
 The hook runs clang-format on staged `.cpp`/`.hpp` files before each commit.
+
+> **Tipp:** EditorConfig-Verstöße (Tabs, Trailing Whitespace) erkennt man am besten mit
+> `editorconfig-checker -exclude '.git|.pio|.vscode|.platformio|build|lib|node_modules'`
+> vor dem Commit — das prüft **alle** Dateitypen, inkl. `platformio.ini`.
 
 ---
 


### PR DESCRIPTION
## Problem

Die lokalen EditorConfig-Checks im `cpp-code-quality`-Skill deckten nur `src/` und `data/web/` ab (C++, HTML, JS, CSS). CI prüft aber **alle** Dateien. Dadurch konnten Tabs/Trailing Whitespace in `platformio.ini`, `.yml`, `.json`, `.md` etc. lokal unentdeckt bleiben — und der CI-Super-Linter schlug erst im PR fehl (siehe PR #96).

## Änderungen

- **Gate 3** (EditorConfig Compliance): Zwei Varianten angeboten
  - Variante A: `editorconfig-checker` (empfohlen) — prüft alle Dateien
  - Variante B: manuelle Checks via `git ls-files` mit allen relevanten Dateitypen
- **Quick Reference**: EditorConfig-Check auf `editorconfig-checker` + `git ls-files` umgestellt
- **Auto-fix**: Erweitert auf `*.ini`, `*.yml`, `*.json`, `*.md`, `*.cfg`, `Makefile` etc.
- **Pre-Commit**: Tipp ergänzt, vor dem Commit `editorconfig-checker` laufen zu lassen

Der `.editorconfig` selbst war bereits korrekt (Rule `[*]` gilt für alle Dateien).