### PR TITLE
chore: support both main and master branches in Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,9 +7,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
   pull_request:
-    branches: [main]
+    branches: [main, master]
   schedule:
     - cron: "0 16 * * 6"
 

--- a/.github/workflows/notify-website-doc.yml
+++ b/.github/workflows/notify-website-doc.yml
@@ -1,8 +1,9 @@
-name: Alert `website` repository on `main` push
+name: Alert `website` repository on `main` or `master` push
 on:
   push:
     branches:
       - main
+      - master
     # Only trigger when doc-related files change — avoids unnecessary website rebuilds
     paths:
       - docs/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Update GitHub Actions to support both `main` and `master` branches
- Update codeql-analysis.yml to trigger on both main and master branches
- Update notify-website-doc.yml to trigger on both main and master branches
- Update release.yml to trigger on both main and master branches

This ensures smooth transition from master to main as the default branch.
