### PR TITLE
fix(wps): correct ESP-IDF version guard for esp_wifi_wps_start API

### DIFF
--- a/src/OtaUpdater.cpp
+++ b/src/OtaUpdater.cpp
@@ -346,8 +346,10 @@ bool OtaUpdater::fetchLatestRelease() {
   downloadUrl_ = "";
   for (JsonObject asset : assets) {
     const char *name = asset["name"];
-    if (!name) continue;
-    if (strstr(name, ".bin") == nullptr) continue;
+    if (!name)
+      continue;
+    if (strstr(name, ".bin") == nullptr)
+      continue;
 
     // Board-specific match takes priority
     if (expectedAsset == String(name)) {

--- a/src/WpsProvisioner.cpp
+++ b/src/WpsProvisioner.cpp
@@ -68,7 +68,7 @@ auto startWps() -> bool {
     return false;
   }
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
   const esp_err_t startErr = esp_wifi_wps_start();
 #else
   const esp_err_t startErr = esp_wifi_wps_start(0);


### PR DESCRIPTION
## Bug

The ESP-IDF version guard in `WpsProvisioner.cpp` checks for `ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)` to decide whether to use the new `esp_wifi_wps_start()` (no arguments) or the old `esp_wifi_wps_start(int)` API.

However, the API change happened in **ESP-IDF 5.0**, not 6.0:

| Version | API |
|---------|-----|
| ESP-IDF 4.x | `esp_wifi_wps_start(int)` |
| ESP-IDF 5.x+ | `esp_wifi_wps_start()` |

The project uses `espressif32 @ 7.0.1` which includes ESP-IDF 5.x, so the current guard would incorrectly call the old 4.x API.

## Fix

Changed the guard from `>= 6, 0, 0` to `>= 5, 0, 0` to match the actual API transition.

## Verification

- [x] cpplint passes
- [x] Builds with espressif32 @ 7.0.1 (ESP-IDF 5.x)