### PR TITLE
fix(mqtt): remove duplicate Home Assistant Discovery entities

### DIFF
--- a/src/MqttPublisher.cpp
+++ b/src/MqttPublisher.cpp
@@ -442,11 +442,6 @@ void MqttPublisher::publishDiscovery() {
   publishSensorDiscovery("solar-sensor-found", "Solar Sensor Found", nullptr, nullptr, "mdi:check-network-outline", "diagnostic");
   publishSensorDiscovery("pool-sensor-found", "Pool Sensor Found", nullptr, nullptr, "mdi:check-network-outline", "diagnostic");
 
-  // ── Configuration (entity_category: "config") ──
-  publishSelectDiscovery("timezone", "Timezone", getTimezoneLabelList(), getTimezoneLabelCount(), "mdi:map-clock", "config");
-  publishNumberDiscovery("hysteresis", "Temperature Hysteresis", 0.0, 10.0, 0.1, "K", "mdi:delta", "config");
-  publishTextDiscovery("ntp-server", "NTP Server", "mdi:clock-outline");
-
   // Firmware Update entity
   publishUpdateDiscovery();
 

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -32,10 +32,8 @@ bool NetworkManager::begin() {
   // Check if WPS button is held down at startup
   WpsProvisioner::runIfRequested();
 
-  // Refresh credentials in case WPS saved them
-  if (WpsProvisioner::runIfRequested != nullptr) {
-    ConfigManager::load();
-  }
+  // WPS may have saved new credentials — reload config
+  ConfigManager::load();
 
   WiFi.onEvent(handleWiFiEvent);
 

--- a/src/OtaUpdater.cpp
+++ b/src/OtaUpdater.cpp
@@ -346,8 +346,10 @@ bool OtaUpdater::fetchLatestRelease() {
   downloadUrl_ = "";
   for (JsonObject asset : assets) {
     const char *name = asset["name"];
-    if (!name) continue;
-    if (strstr(name, ".bin") == nullptr) continue;
+    if (!name)
+      continue;
+    if (strstr(name, ".bin") == nullptr)
+      continue;
 
     // Board-specific match takes priority
     if (expectedAsset == String(name)) {


### PR DESCRIPTION
## Bug

The `publishDiscovery()` method was publishing three entities twice:

| Entity | Line (first) | Line (duplicate) | Problem |
|--------|-------------|------------------|---------|
| `timezone` (select) | 433 | 446 | HA would get duplicate config |
| `hysteresis` (number) | 421 | 447 | Duplicate warnings in HA logs |
| `ntp-server` (text) | 436 (with entity_category: config) | 448 (without entity_category) | The second publish overwrites the category, leaving it without one |

## Fix

Removed the redundant block at lines 445-448, which was leftover from a refactoring.

## Verification

- [x] cpplint passes
- [x] Each entity now publishes exactly once in the correct section