### PR TITLE
fix(network): remove always-true WPS function pointer check

### DIFF
--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -32,10 +32,8 @@ bool NetworkManager::begin() {
   // Check if WPS button is held down at startup
   WpsProvisioner::runIfRequested();
 
-  // Refresh credentials in case WPS saved them
-  if (WpsProvisioner::runIfRequested != nullptr) {
-    ConfigManager::load();
-  }
+  // WPS may have saved new credentials — reload config
+  ConfigManager::load();
 
   WiFi.onEvent(handleWiFiEvent);
 

--- a/src/OtaUpdater.cpp
+++ b/src/OtaUpdater.cpp
@@ -346,8 +346,10 @@ bool OtaUpdater::fetchLatestRelease() {
   downloadUrl_ = "";
   for (JsonObject asset : assets) {
     const char *name = asset["name"];
-    if (!name) continue;
-    if (strstr(name, ".bin") == nullptr) continue;
+    if (!name)
+      continue;
+    if (strstr(name, ".bin") == nullptr)
+      continue;
 
     // Board-specific match takes priority
     if (expectedAsset == String(name)) {


### PR DESCRIPTION
## Bug

In `NetworkManager::begin()`:

```cpp
if (WpsProvisioner::runIfRequested != nullptr) {
  ConfigManager::load();
}
```

`WpsProvisioner::runIfRequested` is a regular static member function (compiled into the binary). Comparing it to `nullptr` is always true — the condition is dead code.

The intent was: "WPS may have run and saved new credentials, reload config."

## Fix

Replaced the dead condition with an unconditional `ConfigManager::load()` call.

## Verification

- [x] cpplint passes
- [x] Logic unchanged (condition was always true)