### PR TITLE
style(ota): fix clang-format violations for inline continue statements

### DIFF
--- a/src/OtaUpdater.cpp
+++ b/src/OtaUpdater.cpp
@@ -346,8 +346,10 @@ bool OtaUpdater::fetchLatestRelease() {
   downloadUrl_ = "";
   for (JsonObject asset : assets) {
     const char *name = asset["name"];
-    if (!name) continue;
-    if (strstr(name, ".bin") == nullptr) continue;
+    if (!name)
+      continue;
+    if (strstr(name, ".bin") == nullptr)
+      continue;
 
     // Board-specific match takes priority
     if (expectedAsset == String(name)) {


### PR DESCRIPTION
## Change

Two inline `continue` statements in `OtaUpdater.cpp:349-350` were flagged by clang-format:

- `if (!name) continue;` → split onto two lines
- `if (strstr(name, ".bin") == nullptr) continue;` → split onto two lines

These are the only MegaLinter CPP/clang-format failures in the entire codebase.

## Verification

- [x] `clang-format --Werror --dry-run` passes on all files
- [x] cpplint passes
- [x] No functional changes