### PR TITLE
fix(pool-controller): stop overriding persisted TimerSetting with hardcoded values

### DIFF
--- a/src/PoolController.cpp
+++ b/src/PoolController.cpp
@@ -251,12 +251,7 @@ auto PoolControllerContext::initializeController() -> void {
   operationModeNode.setSolarMinTemperature(ConfigManager::getSettings().tempMinSolar);
   operationModeNode.setTemperatureHysteresis(ConfigManager::getSettings().tempHysteresis);
 
-  TimerSetting ts = operationModeNode.getTimerSetting();
-  ts.timerStartHour = 10;
-  ts.timerStartMinutes = 30;
-  ts.timerEndHour = 17;
-  ts.timerEndMinutes = 30;
-  operationModeNode.setTimerSetting(ts);
+  // TimerSetting is loaded from NVS by OperationModeNode::begin() — no override needed
 
   operationModeNode.setPoolTemperatureNode(&poolTemperatureNode);
   operationModeNode.setSolarTemperatureNode(&solarTemperatureNode);


### PR DESCRIPTION
## Bug

In `PoolController::initializeController()`, lines 254-259:

```cpp
TimerSetting ts = operationModeNode.getTimerSetting();
ts.timerStartHour = 10;
ts.timerStartMinutes = 30;
ts.timerEndHour = 17;
ts.timerEndMinutes = 30;
operationModeNode.setTimerSetting(ts);
```

This code:
1. Reads the timer setting from `OperationModeNode` (which loads from NVS via `StateManager`)
2. Immediately overwrites it with hardcoded values
3. Any user changes to timer settings via HA or the web portal are silently discarded on reboot

`OperationModeNode::begin()` already loads the persisted setting from NVS with the same defaults (10:30-17:30). The override was redundant and destructive.

## Fix

Removed the hardcoded override block. Timer settings now come from NVS as intended.

## Verification

- [x] No functional regression (same defaults from NVS)
- [x] User-saved timer settings now persist across reboots
- [x] cpplint passes