### PR TITLE
refactor(mqtt): consolidate duplicated device info block into helper method

### DIFF
--- a/src/MqttPublisher.cpp
+++ b/src/MqttPublisher.cpp
@@ -48,11 +48,14 @@ void MqttPublisher::begin() {
   NetworkManager::setMqttCallback(handleMqttMessage);
 }
 
-String MqttPublisher::getDeviceJson() {
-  // Common device block to consolidate all entities in HA (F5 Fix)
-  return String("{\"identifiers\":[\"") + deviceId_ +
-    "\"],\"name\":\"Pool Controller\",\"manufacturer\":\"smart-swimmingpool\",\"model\":\"Pool Controller\",\"sw_version\":\"" +
-    FW_VERSION + "\"}";
+void MqttPublisher::addDeviceInfo(JsonDocument &doc) {
+  // Common device block to consolidate all entities in HA
+  JsonObject deviceObj = doc["device"].to<JsonObject>();
+  deviceObj["identifiers"][0] = deviceId_;
+  deviceObj["name"] = "Pool Controller";
+  deviceObj["manufacturer"] = "smart-swimmingpool";
+  deviceObj["model"] = "Pool Controller";
+  deviceObj["sw_version"] = FW_VERSION;
 }
 
 String MqttPublisher::getBaseTopic(const char *component, const char *objectId) {
@@ -80,12 +83,7 @@ void MqttPublisher::publishSensorDiscovery(const char *objectId, const char *nam
     doc["entity_category"] = entityCategory;
 
   // Embedded device block - manually add device info
-  JsonObject deviceObj = doc["device"].to<JsonObject>();
-  deviceObj["identifiers"][0] = deviceId_;
-  deviceObj["name"] = "Pool Controller";
-  deviceObj["manufacturer"] = "smart-swimmingpool";
-  deviceObj["model"] = "Pool Controller";
-  deviceObj["sw_version"] = FW_VERSION;
+  addDeviceInfo(doc);
 
   String payload;
   serializeJson(doc, payload);
@@ -109,12 +107,7 @@ void MqttPublisher::publishSwitchDiscovery(const char *objectId, const char *nam
   if (entityCategory)
     doc["entity_category"] = entityCategory;
   // Embedded device block - manually add device info
-  JsonObject deviceObj = doc["device"].to<JsonObject>();
-  deviceObj["identifiers"][0] = deviceId_;
-  deviceObj["name"] = "Pool Controller";
-  deviceObj["manufacturer"] = "smart-swimmingpool";
-  deviceObj["model"] = "Pool Controller";
-  deviceObj["sw_version"] = FW_VERSION;
+  addDeviceInfo(doc);
 
   String payload;
   serializeJson(doc, payload);
@@ -142,12 +135,7 @@ void MqttPublisher::publishSelectDiscovery(const char *objectId, const char *nam
   if (entityCategory)
     doc["entity_category"] = entityCategory;
   // Embedded device block - manually add device info
-  JsonObject deviceObj = doc["device"].to<JsonObject>();
-  deviceObj["identifiers"][0] = deviceId_;
-  deviceObj["name"] = "Pool Controller";
-  deviceObj["manufacturer"] = "smart-swimmingpool";
-  deviceObj["model"] = "Pool Controller";
-  deviceObj["sw_version"] = FW_VERSION;
+  addDeviceInfo(doc);
 
   String payload;
   serializeJson(doc, payload);
@@ -176,12 +164,7 @@ void MqttPublisher::publishNumberDiscovery(const char *objectId, const char *nam
   if (entityCategory)
     doc["entity_category"] = entityCategory;
   // Embedded device block - manually add device info
-  JsonObject deviceObj = doc["device"].to<JsonObject>();
-  deviceObj["identifiers"][0] = deviceId_;
-  deviceObj["name"] = "Pool Controller";
-  deviceObj["manufacturer"] = "smart-swimmingpool";
-  deviceObj["model"] = "Pool Controller";
-  deviceObj["sw_version"] = FW_VERSION;
+  addDeviceInfo(doc);
 
   String payload;
   serializeJson(doc, payload);
@@ -203,12 +186,7 @@ void MqttPublisher::publishTextDiscovery(const char *objectId, const char *name,
 
   if (icon)
     doc["icon"] = icon;
-  JsonObject deviceObj = doc["device"].to<JsonObject>();
-  deviceObj["identifiers"][0] = deviceId_;
-  deviceObj["name"] = "Pool Controller";
-  deviceObj["manufacturer"] = "smart-swimmingpool";
-  deviceObj["model"] = "Pool Controller";
-  deviceObj["sw_version"] = FW_VERSION;
+  addDeviceInfo(doc);
 
   String payload;
   serializeJson(doc, payload);
@@ -229,12 +207,7 @@ void MqttPublisher::publishTimeDiscovery(const char *objectId, const char *name,
     doc["icon"] = icon;
   if (entityCategory)
     doc["entity_category"] = entityCategory;
-  JsonObject deviceObj = doc["device"].to<JsonObject>();
-  deviceObj["identifiers"][0] = deviceId_;
-  deviceObj["name"] = "Pool Controller";
-  deviceObj["manufacturer"] = "smart-swimmingpool";
-  deviceObj["model"] = "Pool Controller";
-  deviceObj["sw_version"] = FW_VERSION;
+  addDeviceInfo(doc);
 
   String payload;
   serializeJson(doc, payload);
@@ -256,12 +229,7 @@ void MqttPublisher::publishUpdateDiscovery() {
   doc["device_class"] = "firmware";
   doc["entity_category"] = "config";
 
-  JsonObject deviceObj = doc["device"].to<JsonObject>();
-  deviceObj["identifiers"][0] = deviceId_;
-  deviceObj["name"] = "Pool Controller";
-  deviceObj["manufacturer"] = "smart-swimmingpool";
-  deviceObj["model"] = "Pool Controller";
-  deviceObj["sw_version"] = FW_VERSION;
+  addDeviceInfo(doc);
 
   String payload;
   serializeJson(doc, payload);
@@ -303,12 +271,7 @@ void MqttPublisher::publishClimateDiscovery() {
   doc["entity_category"] = "config";
 
   // Device block
-  JsonObject deviceObj = doc["device"].to<JsonObject>();
-  deviceObj["identifiers"][0] = deviceId_;
-  deviceObj["name"] = "Pool Controller";
-  deviceObj["manufacturer"] = "smart-swimmingpool";
-  deviceObj["model"] = "Pool Controller";
-  deviceObj["sw_version"] = FW_VERSION;
+  addDeviceInfo(doc);
 
   String payload;
   serializeJson(doc, payload);

--- a/src/MqttPublisher.hpp
+++ b/src/MqttPublisher.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <ArduinoJson.h>
 #include <AsyncMqttClient.h>
 
 namespace PoolController {
@@ -64,7 +65,7 @@ private:
   static void publishSensorMappingDiscovery();
 
   static String getBaseTopic(const char *component, const char *objectId);
-  static String getDeviceJson();
+  static void addDeviceInfo(JsonDocument &doc);
   static void publishUpdateState();
   static void publishClimateState();
 


### PR DESCRIPTION
## Problem

The HA Discovery device block (identifiers, name, manufacturer, model, sw_version) was duplicated identically across all 8 discovery methods in `MqttPublisher.cpp`:

| Method | Lines |
|--------|------|
| `publishSensorDiscovery` | 83-88 |
| `publishSwitchDiscovery` | 112-117 |
| `publishSelectDiscovery` | 145-150 |
| `publishNumberDiscovery` | 179-184 |
| `publishTextDiscovery` | 206-211 |
| `publishTimeDiscovery` | 232-237 |
| `publishUpdateDiscovery` | 259-264 |
| `publishClimateDiscovery` | 306-311 |

Meanwhile `getDeviceJson()` was declared and defined but never called anywhere — dead code.

## Fix

1. Replaced `getDeviceJson()` with `addDeviceInfo(JsonDocument &doc)` — a helper that populates the device object directly on the document
2. Replaced all 8 inline device blocks with `addDeviceInfo(doc);`
3. Updated the header accordingly

Net: **-36 LoC**, zero functional change.

## Verification

- [x] cpplint passes
- [x] Every discovery method calls `addDeviceInfo(doc)` exactly once
- [x] No remaining inline device blocks