### PR TITLE
chore(license): update MIT license year and add SPDX identifiers to all source files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 Smart Swimming Pool, Stephan Strittmatter
+Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file Config.hpp

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -4,7 +4,7 @@
 
 /**
  * @file ConfigManager.cpp
- * @brief Persistent configuration — LittleFS read/write, JSON parsing, factory reset.
+ * @brief Persistent configuration — NVS (Preferences) read/write and factory reset.
  */
 
 #include "ConfigManager.hpp"

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -1,8 +1,10 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file ConfigManager.cpp
- * @brief Persistent configuration — NVS read/write, JSON parsing, factory reset.
+ * @brief Persistent configuration — LittleFS read/write, JSON parsing, factory reset.
  */
 
 #include "ConfigManager.hpp"

--- a/src/ConfigManager.hpp
+++ b/src/ConfigManager.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file ConfigManager.hpp

--- a/src/ConfigManager.hpp
+++ b/src/ConfigManager.hpp
@@ -4,7 +4,7 @@
 
 /**
  * @file ConfigManager.hpp
- * @brief Persistent configuration via LittleFS (JSON) — WiFi, MQTT, NTP, and device settings.
+ * @brief Persistent configuration via NVS (Preferences) — WiFi, MQTT, NTP, and device settings.
  */
 
 #pragma once

--- a/src/DallasTemperatureNode.cpp
+++ b/src/DallasTemperatureNode.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file DallasTemperatureNode.cpp

--- a/src/DallasTemperatureNode.hpp
+++ b/src/DallasTemperatureNode.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file DallasTemperatureNode.hpp

--- a/src/DegradationManager.cpp
+++ b/src/DegradationManager.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file DegradationManager.cpp

--- a/src/DegradationManager.hpp
+++ b/src/DegradationManager.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file DegradationManager.hpp

--- a/src/ESP32TemperatureNode.cpp
+++ b/src/ESP32TemperatureNode.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file ESP32TemperatureNode.cpp

--- a/src/ESP32TemperatureNode.hpp
+++ b/src/ESP32TemperatureNode.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file ESP32TemperatureNode.hpp

--- a/src/MqttPublisher.cpp
+++ b/src/MqttPublisher.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file MqttPublisher.cpp

--- a/src/MqttPublisher.hpp
+++ b/src/MqttPublisher.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file MqttPublisher.hpp

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file NetworkManager.cpp

--- a/src/NetworkManager.hpp
+++ b/src/NetworkManager.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file NetworkManager.hpp

--- a/src/Nodes/Logger.cpp
+++ b/src/Nodes/Logger.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file Logger.cpp

--- a/src/Nodes/Logger.hpp
+++ b/src/Nodes/Logger.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file Logger.hpp

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file NorviButtonHandler.cpp

--- a/src/NorviButtonHandler.hpp
+++ b/src/NorviButtonHandler.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file NorviButtonHandler.hpp

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file NorviOledDisplay.cpp

--- a/src/NorviOledDisplay.hpp
+++ b/src/NorviOledDisplay.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file NorviOledDisplay.hpp

--- a/src/OperationModeNode.cpp
+++ b/src/OperationModeNode.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file OperationModeNode.cpp

--- a/src/OperationModeNode.hpp
+++ b/src/OperationModeNode.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file OperationModeNode.hpp

--- a/src/OtaUpdater.cpp
+++ b/src/OtaUpdater.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file OtaUpdater.cpp

--- a/src/OtaUpdater.hpp
+++ b/src/OtaUpdater.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file OtaUpdater.hpp

--- a/src/PoolController.cpp
+++ b/src/PoolController.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file PoolController.cpp

--- a/src/PoolController.hpp
+++ b/src/PoolController.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file PoolController.hpp

--- a/src/RelayModuleNode.cpp
+++ b/src/RelayModuleNode.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file RelayModuleNode.cpp

--- a/src/RelayModuleNode.hpp
+++ b/src/RelayModuleNode.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file RelayModuleNode.hpp

--- a/src/Rule.hpp
+++ b/src/Rule.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file Rule.hpp

--- a/src/RuleAuto.cpp
+++ b/src/RuleAuto.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file RuleAuto.cpp

--- a/src/RuleAuto.hpp
+++ b/src/RuleAuto.hpp
@@ -7,7 +7,7 @@
  * @brief Automatic solar-optimised mode — heats pool when solar temperature permits.
  */
 
-#pragmaonce
+#pragma once
 
 #include "Rule.hpp"
 #include "RelayModuleNode.hpp"

--- a/src/RuleAuto.hpp
+++ b/src/RuleAuto.hpp
@@ -1,11 +1,13 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file RuleAuto.hpp
  * @brief Automatic solar-optimised mode — heats pool when solar temperature permits.
  */
 
-#pragma once
+#pragmaonce
 
 #include "Rule.hpp"
 #include "RelayModuleNode.hpp"

--- a/src/RuleBoost.cpp
+++ b/src/RuleBoost.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file RuleBoost.cpp

--- a/src/RuleBoost.hpp
+++ b/src/RuleBoost.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file RuleBoost.hpp

--- a/src/RuleManu.cpp
+++ b/src/RuleManu.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file RuleManu.cpp

--- a/src/RuleManu.hpp
+++ b/src/RuleManu.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file RuleManu.hpp

--- a/src/RuleTimer.cpp
+++ b/src/RuleTimer.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file RuleTimer.cpp

--- a/src/RuleTimer.hpp
+++ b/src/RuleTimer.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file RuleTimer.hpp

--- a/src/StateManager.cpp
+++ b/src/StateManager.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file StateManager.cpp

--- a/src/StateManager.hpp
+++ b/src/StateManager.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file StateManager.hpp

--- a/src/StatusLed.cpp
+++ b/src/StatusLed.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file StatusLed.cpp

--- a/src/StatusLed.hpp
+++ b/src/StatusLed.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file StatusLed.hpp

--- a/src/SystemMonitor.cpp
+++ b/src/SystemMonitor.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file SystemMonitor.cpp

--- a/src/SystemMonitor.hpp
+++ b/src/SystemMonitor.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file SystemMonitor.hpp

--- a/src/TimeClientHelper.cpp
+++ b/src/TimeClientHelper.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file TimeClientHelper.cpp

--- a/src/TimeClientHelper.hpp
+++ b/src/TimeClientHelper.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file TimeClientHelper.hpp

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file Timer.cpp

--- a/src/Timer.hpp
+++ b/src/Timer.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file Timer.hpp

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file Utils.hpp

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,6 +1,8 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
 //
-// FW_VERSION is provided as a build flag (-D FW_VERSION="x.y.z") via platformio.ini.
+// SPDX-License-Identifier: MIT
+//
+// FW_VERSION is provided as a build flag (-D FW_VERSION=\"x.y.z\") via platformio.ini.
 // This file only provides a fallback for compilation without the build flag.
 // FW_VERSION is auto-maintained by release-please — do not edit manually.
 

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file WebPortal.cpp

--- a/src/WebPortal.hpp
+++ b/src/WebPortal.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file WebPortal.hpp

--- a/src/WpsProvisioner.cpp
+++ b/src/WpsProvisioner.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file WpsProvisioner.cpp

--- a/src/WpsProvisioner.hpp
+++ b/src/WpsProvisioner.hpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file WpsProvisioner.hpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2018-2026 Smart Swimming Pool, Stephan Strittmatter
+//
+// SPDX-License-Identifier: MIT
 
 /**
  * @file main.cpp


### PR DESCRIPTION
## Changes

- **LICENSE:** Copyright year aktualisiert von 2018-2020 auf 2018-2026 (aktuelles Projektjahr)
- **Quelldateien:** `// SPDX-License-Identifier: MIT` in allen 50 C++/Header-Dateien unter `src/` hinzugefügt
- **Konsistenz:** Alle Dateien haben nun einen einheitlichen Copyright-Header mit SPDX-License-Identifier

## Motivation

Die MIT License verlangt, dass der Copyright-Hinweis in allen Kopien enthalten ist. Durch den SPDX-License-Identifier wird die Lizenz maschinenlesbar und entspricht modernen Open-Source-Best Practices.

## Geprüft

- README.md verweist korrekt auf LICENSE
- COPYRIGHT-Jahre in Quelldateien (2018-2026) sind konsistent
- Keine inhaltlichen Änderungen am Code