### PR TITLE
chore(ci): silence MegaLinter release-notice banner, switch to C/C++ flavor

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,4 +9,4 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v7
-      - uses: oxsecurity/megalinter@v9.5.0
+      - uses: oxsecurity/megalinter/flavors/c_cpp@v9.5.0

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -3,6 +3,7 @@
 ---
 APPLY_FIXES: none
 DEFAULT_BRANCH: main
+SECURITY_SUGGESTIONS: false
 
 # Only enable linters relevant to this project (matching old SuperLinter config)
 ENABLE:


### PR DESCRIPTION
## Changes

Two notices from the MegaLinter CI run addressed:

1. **`SECURITY_SUGGESTIONS: false`** — Suppresses the default `MegaLinter 9.5.0 is out!` release banner in CI output
2. **C/C++ flavor** — Switch from `oxsecurity/megalinter` (full image, ~80+ linters) to `oxsecurity/megalinter/flavors/c_cpp` which includes exactly the linters we use (ACTION, BASH, C, CPP, EDITORCONFIG, JSON, MARKDOWN, YAML), resulting in faster image pulls and CI runs

## Related

Closes the notices from [CI run #28401138449](https://github.com/smart-swimmingpool/pool-controller/actions/runs/28401138449)