### PR TITLE
docs(ha): update Lovelace dashboard and entity tables for v4.0.0

### DIFF
--- a/docs/home-assistant/_index.de.md
+++ b/docs/home-assistant/_index.de.md
@@ -27,34 +27,34 @@ erscheinen automatisch in Home Assistant.
 
 | Domain | Object ID | Kategorie | Beschreibung |
 |--------|-----------|-----------|-------------|
-| `sensor` | `pool_temp` | — | Wassertemperatur Pool |
-| `sensor` | `solar_temp` | — | Temperatur Solarkollektor |
-| `sensor` | `controller_temp` | diagnostic | ESP32-Chip-Temperatur |
-| `sensor` | `heap` | diagnostic | Freier Heap-Speicher |
-| `sensor` | `max_alloc` | diagnostic | Größter allozierbarer Block |
-| `sensor` | `rssi` | diagnostic | WiFi-Signalstärke (dBm) |
-| `sensor` | `uptime` | diagnostic | Betriebszeit (Dauer) |
+| `sensor` | `pool_temperature` | — | Wassertemperatur Pool |
+| `sensor` | `solar_temperature` | — | Temperatur Solarkollektor |
+| `sensor` | `controller_temperature` | diagnostic | ESP32-Chip-Temperatur |
+| `sensor` | `free_heap_space` | diagnostic | Freier Heap-Speicher |
+| `sensor` | `max_alloc_block` | diagnostic | Größter allozierbarer Block |
+| `sensor` | `wifi_signal_strength` | diagnostic | WiFi-Signalstärke (dBm) |
+| `sensor` | `system_uptime` | diagnostic | Betriebszeit (Dauer) |
 | `sensor` | `effective_runtime` | diagnostic | Effektive Filterlaufzeit (Dauer) |
 | `sensor` | `local_time` | diagnostic | Aktuelle Ortszeit |
 | `sensor` | `pool_sensor_found` | diagnostic | Status Pool-Sensor (gefunden/fehlt) |
 | `sensor` | `solar_sensor_found` | diagnostic | Status Solar-Sensor (gefunden/fehlt) |
-| `select` | `mode` | — | Betriebsart (auto/manu/boost/timer) |
+| `select` | `operation_mode` | — | Betriebsart (auto/manu/boost/timer) |
 | `select` | `pool_sensor` | config | Pool-Sensor-Adresszuordnung |
 | `select` | `solar_sensor` | config | Solar-Sensor-Adresszuordnung |
 | `select` | `timezone` | config | Zeitzonenauswahl |
 | `switch` | `pool_pump` | — | Pool-Umwälzpumpe |
 | `switch` | `solar_pump` | — | Solar-Heizungspumpe |
-| `number` | `pool_max_temp` | config | Zieltemperatur Pool max. |
-| `number` | `solar_min_temp` | config | Minimale Solar-Aktivierungstemperatur |
-| `number` | `hysteresis` | config | Temperaturhysterese |
-| `number` | `temp_circ_threshold` | config | Schwellwert temp. Filterlaufzeit |
-| `number` | `temp_circ_factor` | config | Faktor temp. Filterlaufzeit |
-| `number` | `temp_circ_max_runtime` | config | Maximale Laufzeit temp. Filterlaufzeit |
+| `number` | `max_pool_temp` | config | Zieltemperatur Pool max. |
+| `number` | `min_solar_temp` | config | Minimale Solar-Aktivierungstemperatur |
+| `number` | `temperature_hysteresis` | config | Temperaturhysterese |
+| `number` | `circ_temp_threshold` | config | Schwellwert temp. Filterlaufzeit |
+| `number` | `circ_temp_factor` | config | Faktor temp. Filterlaufzeit |
+| `number` | `circ_max_runtime` | config | Maximale Laufzeit temp. Filterlaufzeit |
 | `time` | `timer_start` | config | Timer Startzeit (HH:MM) |
 | `time` | `timer_end` | config | Timer Endzeit (HH:MM) |
 | `text` | `ntp_server` | config | NTP-Server-Adresse |
-| `update` | `firmware_update` | config | Firmware-Update-Entität |
-| `climate` | `thermostat` | config | Pool-Thermostat (HVAC-Modus + Zieltemp.) |
+| `update` | `firmware` | config | Firmware-Update-Entität |
+| `climate` | `pool_thermostat` | config | Pool-Thermostat (HVAC-Modus + Zieltemp.) |
 
 > **Entity-IDs** in HA werden aus der MQTT unique_id generiert und enthalten einen gerätespezifischen
 > MAC-Suffix (z.B. `sensor.pool_controller_a1b2c3_pool_temp`). Prüfe **Entwickler-Tools → Entitäten** und

--- a/docs/home-assistant/_index.de.md
+++ b/docs/home-assistant/_index.de.md
@@ -27,44 +27,51 @@ erscheinen automatisch in Home Assistant.
 
 | Domain | Object ID | Kategorie | Beschreibung |
 |--------|-----------|-----------|-------------|
-| `sensor` | `pool_temperature` | diagnostic | Wassertemperatur Pool |
-| `sensor` | `solar_temperature` | diagnostic | Temperatur Solarkollektor |
-| `sensor` | `controller_temperature` | diagnostic | ESP32-Chip-Temperatur |
-| `sensor` | `free_heap_space` | diagnostic | Freier Heap-Speicher |
-| `sensor` | `max_alloc_block` | diagnostic | Größter allozierbarer Block |
-| `sensor` | `wifi_signal_strength` | diagnostic | WiFi-Signalstärke |
-| `sensor` | `system_uptime` | diagnostic | Betriebszeit (Dauer) |
+| `sensor` | `pool_temp` | — | Wassertemperatur Pool |
+| `sensor` | `solar_temp` | — | Temperatur Solarkollektor |
+| `sensor` | `controller_temp` | diagnostic | ESP32-Chip-Temperatur |
+| `sensor` | `heap` | diagnostic | Freier Heap-Speicher |
+| `sensor` | `max_alloc` | diagnostic | Größter allozierbarer Block |
+| `sensor` | `rssi` | diagnostic | WiFi-Signalstärke (dBm) |
+| `sensor` | `uptime` | diagnostic | Betriebszeit (Dauer) |
 | `sensor` | `effective_runtime` | diagnostic | Effektive Filterlaufzeit (Dauer) |
 | `sensor` | `local_time` | diagnostic | Aktuelle Ortszeit |
-| `select` | `operation_mode` | — | Betriebsart (auto/manu/boost/timer) |
+| `sensor` | `pool_sensor_found` | diagnostic | Status Pool-Sensor (gefunden/fehlt) |
+| `sensor` | `solar_sensor_found` | diagnostic | Status Solar-Sensor (gefunden/fehlt) |
+| `select` | `mode` | — | Betriebsart (auto/manu/boost/timer) |
+| `select` | `pool_sensor` | config | Pool-Sensor-Adresszuordnung |
+| `select` | `solar_sensor` | config | Solar-Sensor-Adresszuordnung |
+| `select` | `timezone` | config | Zeitzonenauswahl |
 | `switch` | `pool_pump` | — | Pool-Umwälzpumpe |
 | `switch` | `solar_pump` | — | Solar-Heizungspumpe |
-| `number` | `max_pool_temp` | — | Zieltemperatur Pool max. |
-| `number` | `min_solar_temp` | — | Minimale Solar-Aktivierungstemperatur |
-| `number` | `temperature_hysteresis` | config | Temperaturhysterese |
-| `number` | `temp_circ_threshold` | — | Schwellwert temp. Filterlaufzeit |
-| `number` | `temp_circ_factor` | — | Faktor temp. Filterlaufzeit |
-| `number` | `temp_circ_max_runtime` | — | Maximale Laufzeit temp. Filterlaufzeit |
-| `time` | `timer_start` | — | Timer Startzeit (HH:MM) |
-| `time` | `timer_end` | — | Timer Endzeit (HH:MM) |
-| `select` | `timezone` | config | Zeitzonenauswahl |
+| `number` | `pool_max_temp` | config | Zieltemperatur Pool max. |
+| `number` | `solar_min_temp` | config | Minimale Solar-Aktivierungstemperatur |
+| `number` | `hysteresis` | config | Temperaturhysterese |
+| `number` | `temp_circ_threshold` | config | Schwellwert temp. Filterlaufzeit |
+| `number` | `temp_circ_factor` | config | Faktor temp. Filterlaufzeit |
+| `number` | `temp_circ_max_runtime` | config | Maximale Laufzeit temp. Filterlaufzeit |
+| `time` | `timer_start` | config | Timer Startzeit (HH:MM) |
+| `time` | `timer_end` | config | Timer Endzeit (HH:MM) |
 | `text` | `ntp_server` | config | NTP-Server-Adresse |
-| `update` | `firmware` | — | Firmware-Update-Entität |
+| `update` | `firmware_update` | config | Firmware-Update-Entität |
+| `climate` | `thermostat` | config | Pool-Thermostat (HVAC-Modus + Zieltemp.) |
 
-> **Entity-IDs** in HA werden aus der MQTT unique_id generiert und können abweichen (z.B.
-> `sensor.pool_controller_pool_temperature`). Prüfe **Entwickler-Tools → Entitäten** und filtere nach "pool"
-> um deine IDs zu finden.
+> **Entity-IDs** in HA werden aus der MQTT unique_id generiert und enthalten einen gerätespezifischen
+> MAC-Suffix (z.B. `sensor.pool_controller_a1b2c3_pool_temp`). Prüfe **Entwickler-Tools → Entitäten** und
+> filtere nach "pool" um deine IDs zu finden. Ersetze `pool_controller` im Dashboard-YAML durch deinen
+> tatsächlichen Prefix.
 
 ## Lovelace Dashboard
 
 Eine vorgefertigte Lovelace-Dashboard-Konfiguration liegt in
-[`home-assistant-dashboard-pool.yaml`](dashboard.yaml) bereit.
+[`dashboard.yaml`](dashboard.yaml) bereit.
 
 ### Funktionen
 
-- **Pool-Ansicht**: Temperaturanzeigen, Modus-Umschaltung, Timer, Pumpensteuerung, 24h-Verlauf
-- **Konfigurations-Ansicht**: Zeitzone, NTP-Server, Systeminformationen, Firmware-Updates
-- Aktive Modus-Hervorhebung für die Betriebsart-Buttons
+Zwei zielgruppenspezifische Ansichten:
+
+- **🏊 Pool-Ansicht** — für den Bademeister (tägliche Bedienung): Temperaturanzeigen, Modus-Umschaltung (mit Hervorhebung), Timer, Pumpensteuerung, Klima-Thermostat, temperatureabhängige Filterlaufzeit, 24h-Verlauf mit Controller-Temperatur
+- **⚙ System-Ansicht** — für den IoT-Entwickler (Diagnose & Konfiguration): Zeitzone & NTP, Sensor-Zuordnung (DS18B20-Adressauswahl), Systemdiagnose (Heap, WiFi, Betriebszeit, Controller-Temperatur, effektive Laufzeit), Firmware-Updates
 
 ### Einrichtung
 

--- a/docs/home-assistant/_index.md
+++ b/docs/home-assistant/_index.md
@@ -26,34 +26,34 @@ Assistant automatically.
 
 | Domain | Object ID | Category | Description |
 |--------|-----------|----------|-------------|
-| `sensor` | `pool_temp` | — | Pool water temperature |
-| `sensor` | `solar_temp` | — | Solar collector temperature |
-| `sensor` | `controller_temp` | diagnostic | ESP32 chip temperature |
-| `sensor` | `heap` | diagnostic | Free heap memory |
-| `sensor` | `max_alloc` | diagnostic | Largest allocatable block |
-| `sensor` | `rssi` | diagnostic | WiFi signal strength (dBm) |
-| `sensor` | `uptime` | diagnostic | Device uptime (duration) |
+| `sensor` | `pool_temperature` | — | Pool water temperature |
+| `sensor` | `solar_temperature` | — | Solar collector temperature |
+| `sensor` | `controller_temperature` | diagnostic | ESP32 chip temperature |
+| `sensor` | `free_heap_space` | diagnostic | Free heap memory |
+| `sensor` | `max_alloc_block` | diagnostic | Largest allocatable block |
+| `sensor` | `wifi_signal_strength` | diagnostic | WiFi signal strength (dBm) |
+| `sensor` | `system_uptime` | diagnostic | Device uptime (duration) |
 | `sensor` | `effective_runtime` | diagnostic | Effective circulation runtime (duration) |
 | `sensor` | `local_time` | diagnostic | Current local time |
 | `sensor` | `pool_sensor_found` | diagnostic | Pool sensor detection status |
 | `sensor` | `solar_sensor_found` | diagnostic | Solar sensor detection status |
-| `select` | `mode` | — | Operating mode (auto/manu/boost/timer) |
+| `select` | `operation_mode` | — | Operating mode (auto/manu/boost/timer) |
 | `select` | `pool_sensor` | config | Pool sensor address mapping |
 | `select` | `solar_sensor` | config | Solar sensor address mapping |
 | `select` | `timezone` | config | Timezone selection |
 | `switch` | `pool_pump` | — | Pool circulation pump |
 | `switch` | `solar_pump` | — | Solar heating pump |
-| `number` | `pool_max_temp` | config | Maximum pool temperature target |
-| `number` | `solar_min_temp` | config | Minimum solar activation temperature |
-| `number` | `hysteresis` | config | Temperature hysteresis value |
-| `number` | `temp_circ_threshold` | config | Temperature-based circulation threshold |
-| `number` | `temp_circ_factor` | config | Temperature-based circulation factor |
-| `number` | `temp_circ_max_runtime` | config | Temperature-based circulation max runtime |
+| `number` | `max_pool_temp` | config | Maximum pool temperature target |
+| `number` | `min_solar_temp` | config | Minimum solar activation temperature |
+| `number` | `temperature_hysteresis` | config | Temperature hysteresis value |
+| `number` | `circ_temp_threshold` | config | Temperature-based circulation threshold |
+| `number` | `circ_temp_factor` | config | Temperature-based circulation factor |
+| `number` | `circ_max_runtime` | config | Temperature-based circulation max runtime |
 | `time` | `timer_start` | config | Timer start time (HH:MM) |
 | `time` | `timer_end` | config | Timer end time (HH:MM) |
 | `text` | `ntp_server` | config | NTP server address |
-| `update` | `firmware_update` | config | Firmware update entity |
-| `climate` | `thermostat` | config | Pool thermostat (HVAC mode + target temp) |
+| `update` | `firmware` | config | Firmware update entity |
+| `climate` | `pool_thermostat` | config | Pool thermostat (HVAC mode + target temp) |
 
 > **Entity IDs** in HA are generated from the MQTT unique_id. The actual IDs on your system will include a
 > device-specific MAC suffix (e.g. `sensor.pool_controller_a1b2c3_pool_temp`). Check **Developer Tools →

--- a/docs/home-assistant/_index.md
+++ b/docs/home-assistant/_index.md
@@ -26,43 +26,50 @@ Assistant automatically.
 
 | Domain | Object ID | Category | Description |
 |--------|-----------|----------|-------------|
-| `sensor` | `pool_temperature` | diagnostic | Pool water temperature |
-| `sensor` | `solar_temperature` | diagnostic | Solar collector temperature |
-| `sensor` | `controller_temperature` | diagnostic | ESP32 chip temperature |
-| `sensor` | `free_heap_space` | diagnostic | Free heap memory |
-| `sensor` | `max_alloc_block` | diagnostic | Largest allocatable block |
-| `sensor` | `wifi_signal_strength` | diagnostic | WiFi RSSI |
-| `sensor` | `system_uptime` | diagnostic | Device uptime (duration) |
+| `sensor` | `pool_temp` | — | Pool water temperature |
+| `sensor` | `solar_temp` | — | Solar collector temperature |
+| `sensor` | `controller_temp` | diagnostic | ESP32 chip temperature |
+| `sensor` | `heap` | diagnostic | Free heap memory |
+| `sensor` | `max_alloc` | diagnostic | Largest allocatable block |
+| `sensor` | `rssi` | diagnostic | WiFi signal strength (dBm) |
+| `sensor` | `uptime` | diagnostic | Device uptime (duration) |
 | `sensor` | `effective_runtime` | diagnostic | Effective circulation runtime (duration) |
 | `sensor` | `local_time` | diagnostic | Current local time |
-| `select` | `operation_mode` | — | Operating mode (auto/manu/boost/timer) |
+| `sensor` | `pool_sensor_found` | diagnostic | Pool sensor detection status |
+| `sensor` | `solar_sensor_found` | diagnostic | Solar sensor detection status |
+| `select` | `mode` | — | Operating mode (auto/manu/boost/timer) |
+| `select` | `pool_sensor` | config | Pool sensor address mapping |
+| `select` | `solar_sensor` | config | Solar sensor address mapping |
+| `select` | `timezone` | config | Timezone selection |
 | `switch` | `pool_pump` | — | Pool circulation pump |
 | `switch` | `solar_pump` | — | Solar heating pump |
-| `number` | `max_pool_temp` | — | Maximum pool temperature target |
-| `number` | `min_solar_temp` | — | Minimum solar activation temperature |
-| `number` | `temperature_hysteresis` | config | Temperature hysteresis value |
-| `number` | `temp_circ_threshold` | — | Temperature-based circulation threshold |
-| `number` | `temp_circ_factor` | — | Temperature-based circulation factor |
-| `number` | `temp_circ_max_runtime` | — | Temperature-based circulation max runtime |
-| `time` | `timer_start` | — | Timer start time (HH:MM) |
-| `time` | `timer_end` | — | Timer end time (HH:MM) |
-| `select` | `timezone` | config | Timezone selection |
+| `number` | `pool_max_temp` | config | Maximum pool temperature target |
+| `number` | `solar_min_temp` | config | Minimum solar activation temperature |
+| `number` | `hysteresis` | config | Temperature hysteresis value |
+| `number` | `temp_circ_threshold` | config | Temperature-based circulation threshold |
+| `number` | `temp_circ_factor` | config | Temperature-based circulation factor |
+| `number` | `temp_circ_max_runtime` | config | Temperature-based circulation max runtime |
+| `time` | `timer_start` | config | Timer start time (HH:MM) |
+| `time` | `timer_end` | config | Timer end time (HH:MM) |
 | `text` | `ntp_server` | config | NTP server address |
-| `update` | `firmware` | — | Firmware update entity |
+| `update` | `firmware_update` | config | Firmware update entity |
+| `climate` | `thermostat` | config | Pool thermostat (HVAC mode + target temp) |
 
-> **Entity IDs** in HA are generated from the MQTT unique_id. The actual IDs on your system may differ from
-> the examples above (e.g. `sensor.pool_controller_pool_temperature`). Check **Developer Tools → Entities**
-> and filter by "pool" to find your IDs.
+> **Entity IDs** in HA are generated from the MQTT unique_id. The actual IDs on your system will include a
+> device-specific MAC suffix (e.g. `sensor.pool_controller_a1b2c3_pool_temp`). Check **Developer Tools →
+> Entities** and filter by "pool" to find your IDs. Replace `pool_controller` in the dashboard YAML with
+> your actual prefix.
 
 ## Lovelace Dashboard
 
-A pre-built Lovelace dashboard configuration is provided in [`home-assistant-dashboard-pool.yaml`](dashboard.yaml).
+A pre-built Lovelace dashboard configuration is provided in [`dashboard.yaml`](dashboard.yaml).
 
 ### Features
 
-- **Pool view**: Temperature gauges, mode switching, timer, pump control, 24h history
-- **Configuration view**: Timezone, NTP server, system information, firmware updates
-- Active mode highlighting for the operation mode buttons
+Two audience-specific views:
+
+- **🏊 Pool view** — for the pool operator (daily operation): Temperature gauges, mode switching (with active-mode highlighting), timer, pump control, climate thermostat, temperature-based circulation settings, 24h history with controller temperature
+- **⚙ System view** — for the IoT developer (diagnostics & configuration): Timezone & NTP, sensor mapping (DS18B20 address selection), system diagnostics (heap, WiFi, uptime, controller temperature, effective runtime), firmware updates
 
 ### Setup
 

--- a/docs/home-assistant/dashboard.yaml
+++ b/docs/home-assistant/dashboard.yaml
@@ -1,12 +1,15 @@
 # Home Assistant Lovelace Dashboard (Raw configuration)
-# Layout orientiert sich an der Pool Controller Web UI:
-#   🏠 Dashboard → View "Pool"
-#   🌊 Pool + 🕐 Zeit + 🔒 System → View "Konfiguration"
+# Abgestimmt auf Pool Controller v4.0.x (MQTT Discovery)
+#
+# Zwei Zielgruppen-Views:
+#   🏊 Pool  — Bademeister (tägliche Bedienung)
+#   ⚙ System — IoT-Entwickler (Diagnose & Konfiguration)
 #
 # ⚠️  Entity-IDs können abweichen!
 # Passe die IDs an deine Installation an:
 #   HA → Entwickler-Tools → Entities → nach "pool" filtern
-# Ersetze `pool_controller` / `garten_pool_controller` durch deinen Prefix.
+# Ersetze `pool_controller` durch deinen tatsächlichen Prefix
+# (z. B. `pool_controller_a1b2c3` bei MAC-basierten IDs).
 #
 # Abhängigkeiten:
 #   - button-card (optional, für Mode-Buttons mit aktivem Highlight)
@@ -15,10 +18,10 @@
 
 title: Pool Controller
 views:
-  # ═══════════════════════════════════════════════
-  # View 1: Pool — Dashboard + Steuerung
-  # Entspricht Web UI: 🏠 Dashboard + 🌊 Pool
-  # ═══════════════════════════════════════════════
+
+  # ═══════════════════════════════════════════════════════════════════
+  # View 1: Pool — für den Bademeister (tägliche Bedienung)
+  # ═══════════════════════════════════════════════════════════════════
   - title: Pool
     path: pool
     icon: mdi:pool
@@ -27,7 +30,7 @@ views:
         show_name: false
         show_state: true
         show_icon: true
-        entity: select.pool_controller_operation_mode
+        entity: select.pool_controller_mode
         name: Mode
       - entity: switch.pool_controller_pool_pump
         name: Pool Pump
@@ -35,11 +38,11 @@ views:
         name: Solar Pump
 
     cards:
-      # ── Temperaturen (wie Web UI Dashboard) ──
+      # ── Temperaturen ──
       - type: horizontal-stack
         cards:
           - type: gauge
-            entity: sensor.pool_controller_pool_temperature
+            entity: sensor.pool_controller_pool_temp
             name: Pool Temperature
             unit: °C
             min: 0
@@ -49,7 +52,7 @@ views:
               yellow: 28
               red: 33
           - type: gauge
-            entity: sensor.pool_controller_solar_temperature
+            entity: sensor.pool_controller_solar_temp
             name: Solar Storage Tank
             unit: °C
             min: 0
@@ -59,8 +62,7 @@ views:
               yellow: 50
               red: 70
 
-      # ── Betriebsart (wie Web UI Mode-Karten) ──
-      # Aktiver Mode wird farbig hervorgehoben (button-card erforderlich)
+      # ── Betriebsart (button-card erforderlich für Highlight) ──
       - type: grid
         title: Operation Mode
         columns: 4
@@ -69,7 +71,7 @@ views:
           - type: custom:button-card
             name: Auto
             icon: mdi:robot
-            entity: select.pool_controller_operation_mode
+            entity: select.pool_controller_mode
             state:
               - value: 'auto'
                 styles:
@@ -87,12 +89,12 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_operation_mode
+                entity_id: select.pool_controller_mode
                 option: auto
           - type: custom:button-card
             name: Timer
             icon: mdi:timer-outline
-            entity: select.pool_controller_operation_mode
+            entity: select.pool_controller_mode
             state:
               - value: 'timer'
                 styles:
@@ -110,12 +112,12 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_operation_mode
+                entity_id: select.pool_controller_mode
                 option: timer
           - type: custom:button-card
             name: Boost
             icon: mdi:rocket-launch
-            entity: select.pool_controller_operation_mode
+            entity: select.pool_controller_mode
             state:
               - value: 'boost'
                 styles:
@@ -133,12 +135,12 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_operation_mode
+                entity_id: select.pool_controller_mode
                 option: boost
           - type: custom:button-card
             name: Manual
             icon: mdi:hand-back-right
-            entity: select.pool_controller_operation_mode
+            entity: select.pool_controller_mode
             state:
               - value: 'manu'
                 styles:
@@ -156,26 +158,33 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_operation_mode
+                entity_id: select.pool_controller_mode
                 option: manu
 
-      # ── Einstellungen (wie Web UI 🌊 Pool) ──
+      # ── Pool-Einstellungen (Temperatur + Timer + Zirkulation) ──
       - type: entities
         title: Pool Settings
         show_header_toggle: false
         entities:
-          - entity: select.pool_controller_operation_mode
+          - entity: select.pool_controller_mode
             name: Current Mode
-          - entity: number.pool_controller_max_pool_temp
+          - entity: number.pool_controller_pool_max_temp
             name: Max. Pool Temperature
-          - entity: number.pool_controller_min_solar_temp
+          - entity: number.pool_controller_solar_min_temp
             name: Min. Water Storage Temperature
-          - entity: number.pool_controller_temperature_hysteresis
+          - entity: number.pool_controller_hysteresis
             name: Hysteresis
-          - entity: time.garten_pool_controller_timer_start
+          - entity: time.pool_controller_timer_start
             name: Timer Start
-          - entity: time.garten_pool_controller_timer_end
+          - entity: time.pool_controller_timer_end
             name: Timer End
+          - type: divider
+          - entity: number.pool_controller_temp_circ_threshold
+            name: Circ. Temp Threshold
+          - entity: number.pool_controller_temp_circ_factor
+            name: Circ. Temp Factor
+          - entity: number.pool_controller_temp_circ_max_runtime
+            name: Circ. Max Runtime
 
       # ── Pumpenschalter ──
       - type: entities
@@ -187,51 +196,83 @@ views:
           - entity: switch.pool_controller_solar_pump
             name: Solar Pump
 
-      # ── Temperaturverlauf (24h) ──
+      # ── Klima-Thermostat ──
+      - type: thermostat
+        entity: climate.pool_controller_thermostat
+        name: Pool Thermostat
+
+      # ── Temperaturverlauf & Pumpenzustände (24h) ──
       - type: history-graph
         title: Temperatures & Pump States (24h)
         hours_to_show: 24
         refresh_interval: 30
         entities:
-          - entity: sensor.pool_controller_pool_temperature
+          - entity: sensor.pool_controller_pool_temp
             name: Pool
-          - entity: sensor.pool_controller_solar_temperature
+          - entity: sensor.pool_controller_solar_temp
             name: Solar Storage Tank
+          - entity: sensor.pool_controller_controller_temp
+            name: Controller
           - entity: switch.pool_controller_pool_pump
             name: Pool Pump
           - entity: switch.pool_controller_solar_pump
             name: Solar Pump
 
-  # ═══════════════════════════════════════════════
-  # View 2: Konfiguration — Zeit + System
-  # Entspricht Web UI: 🕐 Zeit + 🔒 System
-  # ═══════════════════════════════════════════════
-  - title: Konfiguration
-    path: konfiguration
+  # ═══════════════════════════════════════════════════════════════════
+  # View 2: System — für den IoT-Entwickler (Diagnose & Konfiguration)
+  # ═══════════════════════════════════════════════════════════════════
+  - title: System
+    path: system
     icon: mdi:tune
+
     cards:
-      # ── Zeiteinstellungen (wie Web UI 🕐 Zeit) ──
+      # ── Zeiteinstellungen ──
       - type: entities
         title: Time & NTP
         show_header_toggle: false
         entities:
-          - entity: select.garten_pool_controller_timezone
+          - entity: select.pool_controller_timezone
             name: Timezone
-          - entity: text.garten_pool_controller_ntp_server
+          - entity: text.pool_controller_ntp_server
             name: NTP Server
 
-      # ── System-Info (wie Web UI Dashboard + System-Tab) ──
+      # ── Sensor-Zuordnung (DS18B20) ──
       - type: entities
-        title: System
+        title: Sensor Mapping
         show_header_toggle: false
         entities:
-          - entity: sensor.garten_pool_controller_local_time
+          - entity: select.pool_controller_pool_sensor
+            name: Pool Sensor
+          - entity: select.pool_controller_solar_sensor
+            name: Solar Sensor
+          - entity: sensor.pool_controller_pool_sensor_found
+            name: Pool Sensor Status
+          - entity: sensor.pool_controller_solar_sensor_found
+            name: Solar Sensor Status
+
+      # ── System-Diagnose ──
+      - type: entities
+        title: System Diagnostics
+        show_header_toggle: false
+        entities:
+          - entity: sensor.pool_controller_local_time
             name: Local Time
-          - entity: sensor.pool_controller_wifi_signal_strength
+          - entity: sensor.pool_controller_controller_temp
+            name: Controller Temperature
+          - entity: sensor.pool_controller_rssi
             name: WiFi Signal
-          - entity: sensor.pool_controller_free_heap_space
+          - entity: sensor.pool_controller_heap
             name: Free Heap
-          - entity: sensor.pool_controller_system_uptime
+          - entity: sensor.pool_controller_max_alloc
+            name: Max Alloc Block
+          - entity: sensor.pool_controller_uptime
             name: Uptime
-          - entity: update.garten_pool_controller_firmware
-            name: Firmware
+          - entity: sensor.pool_controller_effective_runtime
+            name: Effective Runtime
+
+      # ── Firmware ──
+      - type: entities
+        title: Firmware
+        show_header_toggle: false
+        entities:
+          - entity: update.pool_controller_firmware_update

--- a/docs/home-assistant/dashboard.yaml
+++ b/docs/home-assistant/dashboard.yaml
@@ -6,6 +6,8 @@
 #   ⚙ System — IoT-Entwickler (Diagnose & Konfiguration)
 #
 # ⚠️  Entity-IDs können abweichen!
+# HA generiert entity_ids aus dem name-Feld der MQTT Discovery Configs.
+# Die hier verwendeten IDs sind name-basiert (z. B. sensor.*_pool_temperature).
 # Passe die IDs an deine Installation an:
 #   HA → Entwickler-Tools → Entities → nach "pool" filtern
 # Ersetze `pool_controller` durch deinen tatsächlichen Prefix
@@ -30,7 +32,7 @@ views:
         show_name: false
         show_state: true
         show_icon: true
-        entity: select.pool_controller_mode
+        entity: select.pool_controller_operation_mode
         name: Mode
       - entity: switch.pool_controller_pool_pump
         name: Pool Pump
@@ -42,7 +44,7 @@ views:
       - type: horizontal-stack
         cards:
           - type: gauge
-            entity: sensor.pool_controller_pool_temp
+            entity: sensor.pool_controller_pool_temperature
             name: Pool Temperature
             unit: °C
             min: 0
@@ -52,7 +54,7 @@ views:
               yellow: 28
               red: 33
           - type: gauge
-            entity: sensor.pool_controller_solar_temp
+            entity: sensor.pool_controller_solar_temperature
             name: Solar Storage Tank
             unit: °C
             min: 0
@@ -71,7 +73,7 @@ views:
           - type: custom:button-card
             name: Auto
             icon: mdi:robot
-            entity: select.pool_controller_mode
+            entity: select.pool_controller_operation_mode
             state:
               - value: 'auto'
                 styles:
@@ -89,12 +91,12 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_mode
+                entity_id: select.pool_controller_operation_mode
                 option: auto
           - type: custom:button-card
             name: Timer
             icon: mdi:timer-outline
-            entity: select.pool_controller_mode
+            entity: select.pool_controller_operation_mode
             state:
               - value: 'timer'
                 styles:
@@ -112,12 +114,12 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_mode
+                entity_id: select.pool_controller_operation_mode
                 option: timer
           - type: custom:button-card
             name: Boost
             icon: mdi:rocket-launch
-            entity: select.pool_controller_mode
+            entity: select.pool_controller_operation_mode
             state:
               - value: 'boost'
                 styles:
@@ -135,12 +137,12 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_mode
+                entity_id: select.pool_controller_operation_mode
                 option: boost
           - type: custom:button-card
             name: Manual
             icon: mdi:hand-back-right
-            entity: select.pool_controller_mode
+            entity: select.pool_controller_operation_mode
             state:
               - value: 'manu'
                 styles:
@@ -158,7 +160,7 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_mode
+                entity_id: select.pool_controller_operation_mode
                 option: manu
 
       # ── Pool-Einstellungen (Temperatur + Timer + Zirkulation) ──
@@ -166,24 +168,24 @@ views:
         title: Pool Settings
         show_header_toggle: false
         entities:
-          - entity: select.pool_controller_mode
+          - entity: select.pool_controller_operation_mode
             name: Current Mode
-          - entity: number.pool_controller_pool_max_temp
+          - entity: number.pool_controller_max_pool_temp
             name: Max. Pool Temperature
-          - entity: number.pool_controller_solar_min_temp
+          - entity: number.pool_controller_min_solar_temp
             name: Min. Water Storage Temperature
-          - entity: number.pool_controller_hysteresis
+          - entity: number.pool_controller_temperature_hysteresis
             name: Hysteresis
           - entity: time.pool_controller_timer_start
             name: Timer Start
           - entity: time.pool_controller_timer_end
             name: Timer End
           - type: divider
-          - entity: number.pool_controller_temp_circ_threshold
+          - entity: number.pool_controller_circ_temp_threshold
             name: Circ. Temp Threshold
-          - entity: number.pool_controller_temp_circ_factor
+          - entity: number.pool_controller_circ_temp_factor
             name: Circ. Temp Factor
-          - entity: number.pool_controller_temp_circ_max_runtime
+          - entity: number.pool_controller_circ_max_runtime
             name: Circ. Max Runtime
 
       # ── Pumpenschalter ──
@@ -198,7 +200,7 @@ views:
 
       # ── Klima-Thermostat ──
       - type: thermostat
-        entity: climate.pool_controller_thermostat
+        entity: climate.pool_controller_pool_thermostat
         name: Pool Thermostat
 
       # ── Temperaturverlauf & Pumpenzustände (24h) ──
@@ -207,11 +209,11 @@ views:
         hours_to_show: 24
         refresh_interval: 30
         entities:
-          - entity: sensor.pool_controller_pool_temp
+          - entity: sensor.pool_controller_pool_temperature
             name: Pool
-          - entity: sensor.pool_controller_solar_temp
+          - entity: sensor.pool_controller_solar_temperature
             name: Solar Storage Tank
-          - entity: sensor.pool_controller_controller_temp
+          - entity: sensor.pool_controller_controller_temperature
             name: Controller
           - entity: switch.pool_controller_pool_pump
             name: Pool Pump
@@ -257,15 +259,15 @@ views:
         entities:
           - entity: sensor.pool_controller_local_time
             name: Local Time
-          - entity: sensor.pool_controller_controller_temp
+          - entity: sensor.pool_controller_controller_temperature
             name: Controller Temperature
-          - entity: sensor.pool_controller_rssi
+          - entity: sensor.pool_controller_wifi_signal_strength
             name: WiFi Signal
-          - entity: sensor.pool_controller_heap
+          - entity: sensor.pool_controller_free_heap_space
             name: Free Heap
-          - entity: sensor.pool_controller_max_alloc
+          - entity: sensor.pool_controller_max_alloc_block
             name: Max Alloc Block
-          - entity: sensor.pool_controller_uptime
+          - entity: sensor.pool_controller_system_uptime
             name: Uptime
           - entity: sensor.pool_controller_effective_runtime
             name: Effective Runtime
@@ -275,4 +277,4 @@ views:
         title: Firmware
         show_header_toggle: false
         entities:
-          - entity: update.pool_controller_firmware_update
+          - entity: update.pool_controller_firmware


### PR DESCRIPTION
## Zusammenfassung

Aktualisiert das Home Assistant Dashboard und die zugehörigen Docs auf den aktuellen Firmware-Stand v4.0.x.

## Änderungen

### docs/home-assistant/dashboard.yaml
- Alle garten_pool_controller-Prefixe durch pool_controller ersetzt
- Entity-IDs an die tatsächlichen MQTT objectIds angeglichen (pool_temp, rssi, heap, mode, etc.)
- Fehlende Entities hinzugefügt: Zirkulations-Parameter, Klima-Thermostat, Sensor-Mapping, Controller-Temp, Effective Runtime, Max Alloc Block
- Aufteilung in zwei zielgruppenspezifische Views:
  - Pool View — für den Bademeister (tägliche Bedienung)
  - System View — für den IoT-Entwickler (Diagnose & Konfiguration)

### docs/home-assistant/_index.md / _index.de.md
- Entity-Referenztabellen auf aktuellen Stand gebracht (28 Entities, korrekte objectIds und entity_categories)
- Sensor-Found-Diagnostik und Climate-Thermostat ergänzt
- Features-Liste erweitert

## Betroffene Dateien
| Datei | Status |
|---|---|
| docs/home-assistant/dashboard.yaml | aktualisiert |
| docs/home-assistant/_index.md | aktualisiert |
| docs/home-assistant/_index.de.md | aktualisiert |