### PR TITLE
docs: update openHAB integration docs for Home Assistant Discovery

### DIFF
--- a/docs/_index.de.md
+++ b/docs/_index.de.md
@@ -37,7 +37,7 @@ Steuer deinen Swimming-Pool auf smarte Art und Weise, um diesen bequem und güns
 - [x] [Home Assistant MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) - Native HA-Integration
 - [x] Unabhängig von einzelnen Smarthome-Servern
   - [x] [Home Assistant](https://home-assistant.io) via nativer MQTT Discovery
-  - [x] [openHAB](https://www.openhab.org) via MQTT
+  - [x] [openHAB](https://www.openhab.org) via MQTT (manuelle Konfiguration erforderlich)
 - [x] Automatische Zeitsynchronisierung mit NTP (europe.pool.ntp.org)
 - [x] System-Logging und Diagnose-Ereignisse
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -37,7 +37,7 @@ Manage your swimming pool in a smart way to enjoy it comfortably and affordably 
 - [x] [Home Assistant MQTT Discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) - Native HA integration
 - [x] Independent of specific smarthome servers
   - [x] [Home Assistant](https://home-assistant.io) via native MQTT Discovery
-  - [x] [openHAB](https://www.openhab.org) via MQTT
+  - [x] [openHAB](https://www.openhab.org) via MQTT (manual configuration required)
 - [x] Timesync via NTP (europe.pool.ntp.org)
 - [x] Logging of system events and diagnostics
 

--- a/docs/home-assistant/_index.de.md
+++ b/docs/home-assistant/_index.de.md
@@ -27,44 +27,51 @@ erscheinen automatisch in Home Assistant.
 
 | Domain | Object ID | Kategorie | Beschreibung |
 |--------|-----------|-----------|-------------|
-| `sensor` | `pool_temperature` | diagnostic | Wassertemperatur Pool |
-| `sensor` | `solar_temperature` | diagnostic | Temperatur Solarkollektor |
-| `sensor` | `controller_temperature` | diagnostic | ESP32-Chip-Temperatur |
-| `sensor` | `free_heap_space` | diagnostic | Freier Heap-Speicher |
-| `sensor` | `max_alloc_block` | diagnostic | Größter allozierbarer Block |
-| `sensor` | `wifi_signal_strength` | diagnostic | WiFi-Signalstärke |
-| `sensor` | `system_uptime` | diagnostic | Betriebszeit (Dauer) |
+| `sensor` | `pool_temp` | — | Wassertemperatur Pool |
+| `sensor` | `solar_temp` | — | Temperatur Solarkollektor |
+| `sensor` | `controller_temp` | diagnostic | ESP32-Chip-Temperatur |
+| `sensor` | `heap` | diagnostic | Freier Heap-Speicher |
+| `sensor` | `max_alloc` | diagnostic | Größter allozierbarer Block |
+| `sensor` | `rssi` | diagnostic | WiFi-Signalstärke (dBm) |
+| `sensor` | `uptime` | diagnostic | Betriebszeit (Dauer) |
 | `sensor` | `effective_runtime` | diagnostic | Effektive Filterlaufzeit (Dauer) |
 | `sensor` | `local_time` | diagnostic | Aktuelle Ortszeit |
-| `select` | `operation_mode` | — | Betriebsart (auto/manu/boost/timer) |
+| `sensor` | `pool_sensor_found` | diagnostic | Status Pool-Sensor (gefunden/fehlt) |
+| `sensor` | `solar_sensor_found` | diagnostic | Status Solar-Sensor (gefunden/fehlt) |
+| `select` | `mode` | — | Betriebsart (auto/manu/boost/timer) |
+| `select` | `pool_sensor` | config | Pool-Sensor-Adresszuordnung |
+| `select` | `solar_sensor` | config | Solar-Sensor-Adresszuordnung |
+| `select` | `timezone` | config | Zeitzonenauswahl |
 | `switch` | `pool_pump` | — | Pool-Umwälzpumpe |
 | `switch` | `solar_pump` | — | Solar-Heizungspumpe |
-| `number` | `max_pool_temp` | — | Zieltemperatur Pool max. |
-| `number` | `min_solar_temp` | — | Minimale Solar-Aktivierungstemperatur |
-| `number` | `temperature_hysteresis` | config | Temperaturhysterese |
-| `number` | `temp_circ_threshold` | — | Schwellwert temp. Filterlaufzeit |
-| `number` | `temp_circ_factor` | — | Faktor temp. Filterlaufzeit |
-| `number` | `temp_circ_max_runtime` | — | Maximale Laufzeit temp. Filterlaufzeit |
-| `time` | `timer_start` | — | Timer Startzeit (HH:MM) |
-| `time` | `timer_end` | — | Timer Endzeit (HH:MM) |
-| `select` | `timezone` | config | Zeitzonenauswahl |
+| `number` | `pool_max_temp` | config | Zieltemperatur Pool max. |
+| `number` | `solar_min_temp` | config | Minimale Solar-Aktivierungstemperatur |
+| `number` | `hysteresis` | config | Temperaturhysterese |
+| `number` | `temp_circ_threshold` | config | Schwellwert temp. Filterlaufzeit |
+| `number` | `temp_circ_factor` | config | Faktor temp. Filterlaufzeit |
+| `number` | `temp_circ_max_runtime` | config | Maximale Laufzeit temp. Filterlaufzeit |
+| `time` | `timer_start` | config | Timer Startzeit (HH:MM) |
+| `time` | `timer_end` | config | Timer Endzeit (HH:MM) |
 | `text` | `ntp_server` | config | NTP-Server-Adresse |
-| `update` | `firmware` | — | Firmware-Update-Entität |
+| `update` | `firmware_update` | config | Firmware-Update-Entität |
+| `climate` | `thermostat` | config | Pool-Thermostat (HVAC-Modus + Zieltemp.) |
 
-> **Entity-IDs** in HA werden aus der MQTT unique_id generiert und können abweichen (z.B.
-> `sensor.pool_controller_pool_temperature`). Prüfe **Entwickler-Tools → Entitäten** und filtere nach "pool"
-> um deine IDs zu finden.
+> **Entity-IDs** in HA werden aus der MQTT unique_id generiert und enthalten einen gerätespezifischen
+> MAC-Suffix (z.B. `sensor.pool_controller_a1b2c3_pool_temp`). Prüfe **Entwickler-Tools → Entitäten** und
+> filtere nach "pool" um deine IDs zu finden. Ersetze `pool_controller` im Dashboard-YAML durch deinen
+> tatsächlichen Prefix.
 
 ## Lovelace Dashboard
 
 Eine vorgefertigte Lovelace-Dashboard-Konfiguration liegt in
-[`home-assistant-dashboard-pool.yaml`](dashboard.yaml) bereit.
+[`dashboard.yaml`](dashboard.yaml) bereit.
 
 ### Funktionen
 
-- **Pool-Ansicht**: Temperaturanzeigen, Modus-Umschaltung, Timer, Pumpensteuerung, 24h-Verlauf
-- **Konfigurations-Ansicht**: Zeitzone, NTP-Server, Systeminformationen, Firmware-Updates
-- Aktive Modus-Hervorhebung für die Betriebsart-Buttons
+Zwei zielgruppenspezifische Ansichten:
+
+- **🏊 Pool-Ansicht** — für den Bademeister (tägliche Bedienung): Temperaturanzeigen, Modus-Umschaltung (mit Hervorhebung), Timer, Pumpensteuerung, Klima-Thermostat, temperatureabhängige Filterlaufzeit, 24h-Verlauf mit Controller-Temperatur
+- **⚙ System-Ansicht** — für den IoT-Entwickler (Diagnose & Konfiguration): Zeitzone & NTP, Sensor-Zuordnung (DS18B20-Adressauswahl), Systemdiagnose (Heap, WiFi, Betriebszeit, Controller-Temperatur, effektive Laufzeit), Firmware-Updates
 
 ### Einrichtung
 

--- a/docs/home-assistant/_index.md
+++ b/docs/home-assistant/_index.md
@@ -26,43 +26,50 @@ Assistant automatically.
 
 | Domain | Object ID | Category | Description |
 |--------|-----------|----------|-------------|
-| `sensor` | `pool_temperature` | diagnostic | Pool water temperature |
-| `sensor` | `solar_temperature` | diagnostic | Solar collector temperature |
-| `sensor` | `controller_temperature` | diagnostic | ESP32 chip temperature |
-| `sensor` | `free_heap_space` | diagnostic | Free heap memory |
-| `sensor` | `max_alloc_block` | diagnostic | Largest allocatable block |
-| `sensor` | `wifi_signal_strength` | diagnostic | WiFi RSSI |
-| `sensor` | `system_uptime` | diagnostic | Device uptime (duration) |
+| `sensor` | `pool_temp` | — | Pool water temperature |
+| `sensor` | `solar_temp` | — | Solar collector temperature |
+| `sensor` | `controller_temp` | diagnostic | ESP32 chip temperature |
+| `sensor` | `heap` | diagnostic | Free heap memory |
+| `sensor` | `max_alloc` | diagnostic | Largest allocatable block |
+| `sensor` | `rssi` | diagnostic | WiFi signal strength (dBm) |
+| `sensor` | `uptime` | diagnostic | Device uptime (duration) |
 | `sensor` | `effective_runtime` | diagnostic | Effective circulation runtime (duration) |
 | `sensor` | `local_time` | diagnostic | Current local time |
-| `select` | `operation_mode` | — | Operating mode (auto/manu/boost/timer) |
+| `sensor` | `pool_sensor_found` | diagnostic | Pool sensor detection status |
+| `sensor` | `solar_sensor_found` | diagnostic | Solar sensor detection status |
+| `select` | `mode` | — | Operating mode (auto/manu/boost/timer) |
+| `select` | `pool_sensor` | config | Pool sensor address mapping |
+| `select` | `solar_sensor` | config | Solar sensor address mapping |
+| `select` | `timezone` | config | Timezone selection |
 | `switch` | `pool_pump` | — | Pool circulation pump |
 | `switch` | `solar_pump` | — | Solar heating pump |
-| `number` | `max_pool_temp` | — | Maximum pool temperature target |
-| `number` | `min_solar_temp` | — | Minimum solar activation temperature |
-| `number` | `temperature_hysteresis` | config | Temperature hysteresis value |
-| `number` | `temp_circ_threshold` | — | Temperature-based circulation threshold |
-| `number` | `temp_circ_factor` | — | Temperature-based circulation factor |
-| `number` | `temp_circ_max_runtime` | — | Temperature-based circulation max runtime |
-| `time` | `timer_start` | — | Timer start time (HH:MM) |
-| `time` | `timer_end` | — | Timer end time (HH:MM) |
-| `select` | `timezone` | config | Timezone selection |
+| `number` | `pool_max_temp` | config | Maximum pool temperature target |
+| `number` | `solar_min_temp` | config | Minimum solar activation temperature |
+| `number` | `hysteresis` | config | Temperature hysteresis value |
+| `number` | `temp_circ_threshold` | config | Temperature-based circulation threshold |
+| `number` | `temp_circ_factor` | config | Temperature-based circulation factor |
+| `number` | `temp_circ_max_runtime` | config | Temperature-based circulation max runtime |
+| `time` | `timer_start` | config | Timer start time (HH:MM) |
+| `time` | `timer_end` | config | Timer end time (HH:MM) |
 | `text` | `ntp_server` | config | NTP server address |
-| `update` | `firmware` | — | Firmware update entity |
+| `update` | `firmware_update` | config | Firmware update entity |
+| `climate` | `thermostat` | config | Pool thermostat (HVAC mode + target temp) |
 
-> **Entity IDs** in HA are generated from the MQTT unique_id. The actual IDs on your system may differ from
-> the examples above (e.g. `sensor.pool_controller_pool_temperature`). Check **Developer Tools → Entities**
-> and filter by "pool" to find your IDs.
+> **Entity IDs** in HA are generated from the MQTT unique_id. The actual IDs on your system will include a
+> device-specific MAC suffix (e.g. `sensor.pool_controller_a1b2c3_pool_temp`). Check **Developer Tools →
+> Entities** and filter by "pool" to find your IDs. Replace `pool_controller` in the dashboard YAML with
+> your actual prefix.
 
 ## Lovelace Dashboard
 
-A pre-built Lovelace dashboard configuration is provided in [`home-assistant-dashboard-pool.yaml`](dashboard.yaml).
+A pre-built Lovelace dashboard configuration is provided in [`dashboard.yaml`](dashboard.yaml).
 
 ### Features
 
-- **Pool view**: Temperature gauges, mode switching, timer, pump control, 24h history
-- **Configuration view**: Timezone, NTP server, system information, firmware updates
-- Active mode highlighting for the operation mode buttons
+Two audience-specific views:
+
+- **🏊 Pool view** — for the pool operator (daily operation): Temperature gauges, mode switching (with active-mode highlighting), timer, pump control, climate thermostat, temperature-based circulation settings, 24h history with controller temperature
+- **⚙ System view** — for the IoT developer (diagnostics & configuration): Timezone & NTP, sensor mapping (DS18B20 address selection), system diagnostics (heap, WiFi, uptime, controller temperature, effective runtime), firmware updates
 
 ### Setup
 

--- a/docs/home-assistant/dashboard.yaml
+++ b/docs/home-assistant/dashboard.yaml
@@ -1,12 +1,15 @@
 # Home Assistant Lovelace Dashboard (Raw configuration)
-# Layout orientiert sich an der Pool Controller Web UI:
-#   🏠 Dashboard → View "Pool"
-#   🌊 Pool + 🕐 Zeit + 🔒 System → View "Konfiguration"
+# Abgestimmt auf Pool Controller v4.0.x (MQTT Discovery)
+#
+# Zwei Zielgruppen-Views:
+#   🏊 Pool  — Bademeister (tägliche Bedienung)
+#   ⚙ System — IoT-Entwickler (Diagnose & Konfiguration)
 #
 # ⚠️  Entity-IDs können abweichen!
 # Passe die IDs an deine Installation an:
 #   HA → Entwickler-Tools → Entities → nach "pool" filtern
-# Ersetze `pool_controller` / `garten_pool_controller` durch deinen Prefix.
+# Ersetze `pool_controller` durch deinen tatsächlichen Prefix
+# (z. B. `pool_controller_a1b2c3` bei MAC-basierten IDs).
 #
 # Abhängigkeiten:
 #   - button-card (optional, für Mode-Buttons mit aktivem Highlight)
@@ -15,10 +18,10 @@
 
 title: Pool Controller
 views:
-  # ═══════════════════════════════════════════════
-  # View 1: Pool — Dashboard + Steuerung
-  # Entspricht Web UI: 🏠 Dashboard + 🌊 Pool
-  # ═══════════════════════════════════════════════
+
+  # ═══════════════════════════════════════════════════════════════════
+  # View 1: Pool — für den Bademeister (tägliche Bedienung)
+  # ═══════════════════════════════════════════════════════════════════
   - title: Pool
     path: pool
     icon: mdi:pool
@@ -27,7 +30,7 @@ views:
         show_name: false
         show_state: true
         show_icon: true
-        entity: select.pool_controller_operation_mode
+        entity: select.pool_controller_mode
         name: Mode
       - entity: switch.pool_controller_pool_pump
         name: Pool Pump
@@ -35,11 +38,11 @@ views:
         name: Solar Pump
 
     cards:
-      # ── Temperaturen (wie Web UI Dashboard) ──
+      # ── Temperaturen ──
       - type: horizontal-stack
         cards:
           - type: gauge
-            entity: sensor.pool_controller_pool_temperature
+            entity: sensor.pool_controller_pool_temp
             name: Pool Temperature
             unit: °C
             min: 0
@@ -49,7 +52,7 @@ views:
               yellow: 28
               red: 33
           - type: gauge
-            entity: sensor.pool_controller_solar_temperature
+            entity: sensor.pool_controller_solar_temp
             name: Solar Storage Tank
             unit: °C
             min: 0
@@ -59,8 +62,7 @@ views:
               yellow: 50
               red: 70
 
-      # ── Betriebsart (wie Web UI Mode-Karten) ──
-      # Aktiver Mode wird farbig hervorgehoben (button-card erforderlich)
+      # ── Betriebsart (button-card erforderlich für Highlight) ──
       - type: grid
         title: Operation Mode
         columns: 4
@@ -69,7 +71,7 @@ views:
           - type: custom:button-card
             name: Auto
             icon: mdi:robot
-            entity: select.pool_controller_operation_mode
+            entity: select.pool_controller_mode
             state:
               - value: 'auto'
                 styles:
@@ -87,12 +89,12 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_operation_mode
+                entity_id: select.pool_controller_mode
                 option: auto
           - type: custom:button-card
             name: Timer
             icon: mdi:timer-outline
-            entity: select.pool_controller_operation_mode
+            entity: select.pool_controller_mode
             state:
               - value: 'timer'
                 styles:
@@ -110,12 +112,12 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_operation_mode
+                entity_id: select.pool_controller_mode
                 option: timer
           - type: custom:button-card
             name: Boost
             icon: mdi:rocket-launch
-            entity: select.pool_controller_operation_mode
+            entity: select.pool_controller_mode
             state:
               - value: 'boost'
                 styles:
@@ -133,12 +135,12 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_operation_mode
+                entity_id: select.pool_controller_mode
                 option: boost
           - type: custom:button-card
             name: Manual
             icon: mdi:hand-back-right
-            entity: select.pool_controller_operation_mode
+            entity: select.pool_controller_mode
             state:
               - value: 'manu'
                 styles:
@@ -156,26 +158,33 @@ views:
               action: call-service
               service: select.select_option
               service_data:
-                entity_id: select.pool_controller_operation_mode
+                entity_id: select.pool_controller_mode
                 option: manu
 
-      # ── Einstellungen (wie Web UI 🌊 Pool) ──
+      # ── Pool-Einstellungen (Temperatur + Timer + Zirkulation) ──
       - type: entities
         title: Pool Settings
         show_header_toggle: false
         entities:
-          - entity: select.pool_controller_operation_mode
+          - entity: select.pool_controller_mode
             name: Current Mode
-          - entity: number.pool_controller_max_pool_temp
+          - entity: number.pool_controller_pool_max_temp
             name: Max. Pool Temperature
-          - entity: number.pool_controller_min_solar_temp
+          - entity: number.pool_controller_solar_min_temp
             name: Min. Water Storage Temperature
-          - entity: number.pool_controller_temperature_hysteresis
+          - entity: number.pool_controller_hysteresis
             name: Hysteresis
-          - entity: time.garten_pool_controller_timer_start
+          - entity: time.pool_controller_timer_start
             name: Timer Start
-          - entity: time.garten_pool_controller_timer_end
+          - entity: time.pool_controller_timer_end
             name: Timer End
+          - type: divider
+          - entity: number.pool_controller_temp_circ_threshold
+            name: Circ. Temp Threshold
+          - entity: number.pool_controller_temp_circ_factor
+            name: Circ. Temp Factor
+          - entity: number.pool_controller_temp_circ_max_runtime
+            name: Circ. Max Runtime
 
       # ── Pumpenschalter ──
       - type: entities
@@ -187,51 +196,83 @@ views:
           - entity: switch.pool_controller_solar_pump
             name: Solar Pump
 
-      # ── Temperaturverlauf (24h) ──
+      # ── Klima-Thermostat ──
+      - type: thermostat
+        entity: climate.pool_controller_thermostat
+        name: Pool Thermostat
+
+      # ── Temperaturverlauf & Pumpenzustände (24h) ──
       - type: history-graph
         title: Temperatures & Pump States (24h)
         hours_to_show: 24
         refresh_interval: 30
         entities:
-          - entity: sensor.pool_controller_pool_temperature
+          - entity: sensor.pool_controller_pool_temp
             name: Pool
-          - entity: sensor.pool_controller_solar_temperature
+          - entity: sensor.pool_controller_solar_temp
             name: Solar Storage Tank
+          - entity: sensor.pool_controller_controller_temp
+            name: Controller
           - entity: switch.pool_controller_pool_pump
             name: Pool Pump
           - entity: switch.pool_controller_solar_pump
             name: Solar Pump
 
-  # ═══════════════════════════════════════════════
-  # View 2: Konfiguration — Zeit + System
-  # Entspricht Web UI: 🕐 Zeit + 🔒 System
-  # ═══════════════════════════════════════════════
-  - title: Konfiguration
-    path: konfiguration
+  # ═══════════════════════════════════════════════════════════════════
+  # View 2: System — für den IoT-Entwickler (Diagnose & Konfiguration)
+  # ═══════════════════════════════════════════════════════════════════
+  - title: System
+    path: system
     icon: mdi:tune
+
     cards:
-      # ── Zeiteinstellungen (wie Web UI 🕐 Zeit) ──
+      # ── Zeiteinstellungen ──
       - type: entities
         title: Time & NTP
         show_header_toggle: false
         entities:
-          - entity: select.garten_pool_controller_timezone
+          - entity: select.pool_controller_timezone
             name: Timezone
-          - entity: text.garten_pool_controller_ntp_server
+          - entity: text.pool_controller_ntp_server
             name: NTP Server
 
-      # ── System-Info (wie Web UI Dashboard + System-Tab) ──
+      # ── Sensor-Zuordnung (DS18B20) ──
       - type: entities
-        title: System
+        title: Sensor Mapping
         show_header_toggle: false
         entities:
-          - entity: sensor.garten_pool_controller_local_time
+          - entity: select.pool_controller_pool_sensor
+            name: Pool Sensor
+          - entity: select.pool_controller_solar_sensor
+            name: Solar Sensor
+          - entity: sensor.pool_controller_pool_sensor_found
+            name: Pool Sensor Status
+          - entity: sensor.pool_controller_solar_sensor_found
+            name: Solar Sensor Status
+
+      # ── System-Diagnose ──
+      - type: entities
+        title: System Diagnostics
+        show_header_toggle: false
+        entities:
+          - entity: sensor.pool_controller_local_time
             name: Local Time
-          - entity: sensor.pool_controller_wifi_signal_strength
+          - entity: sensor.pool_controller_controller_temp
+            name: Controller Temperature
+          - entity: sensor.pool_controller_rssi
             name: WiFi Signal
-          - entity: sensor.pool_controller_free_heap_space
+          - entity: sensor.pool_controller_heap
             name: Free Heap
-          - entity: sensor.pool_controller_system_uptime
+          - entity: sensor.pool_controller_max_alloc
+            name: Max Alloc Block
+          - entity: sensor.pool_controller_uptime
             name: Uptime
-          - entity: update.garten_pool_controller_firmware
-            name: Firmware
+          - entity: sensor.pool_controller_effective_runtime
+            name: Effective Runtime
+
+      # ── Firmware ──
+      - type: entities
+        title: Firmware
+        show_header_toggle: false
+        entities:
+          - entity: update.pool_controller_firmware_update

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -325,35 +325,33 @@ A ready-to-use **Lovelace dashboard** is available in the repository:
 #### 1️⃣ Prerequisites
 
 - openHAB installed (see [https://www.openhab.org/](https://www.openhab.org/)).
-- MQTT Binding installed (via **Paper UI > Add-ons > Bindings > MQTT Binding**).
+- MQTT Binding installed (via **Add-ons → Bindings → MQTT Binding**).
 
 #### 2️⃣ Configure MQTT Broker
 
-1. Edit the MQTT configuration file:
+Since v3.3.0 the controller uses **Home Assistant MQTT Discovery** exclusively.
+openHAB does not support HA Discovery natively, so you need to manually add
+the controller as **MQTT Things** using the raw topic structure.
+
+1. Add your MQTT broker in openHAB (openHAB 3+: **Settings → Things → `+` → MQTT Broker**).
+
+2. Create a **New Thing** from the MQTT Binding and subscribe to the topic:
+   `homeassistant/#`
+
+3. Restart openHAB or refresh the MQTT Binding:
 
    ```bash
-   sudo nano /etc/openhab2/services/mqtt.cfg
+   sudo systemctl restart openhab
    ```
 
-2. Add your broker settings:
+#### 3️⃣ Discover & Configure Things
 
-   ```ini
-   mqtt:broker.url=tcp://localhost:1883
-   mqtt:broker.clientId=openhab
-   mqtt:broker.user=your_username
-   mqtt:broker.password=your_password
-   ```
+After the broker is set up, the controller's entities should appear as
+discoverable Things under `homeassistant/#`. If they don't appear automatically,
+you can manually create Things by subscribing to the individual state/command topics.
 
-3. Restart openHAB:
-
-   ```bash
-   sudo systemctl restart openhab2
-   ```
-
-#### 3️⃣ Manually Add Devices
-
-Since **Homie support was removed in v3.3.0**, you need to manually configure the MQTT topics in openHAB.
-See the [openHAB Configuration Guide](https://github.com/smart-swimmingpool/openhab-config) for examples.
+See the [openHAB Configuration Guide](https://github.com/smart-swimmingpool/openhab-config)
+for ready-to-use `.things` and `.items` examples.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -362,17 +362,15 @@ Hier ist ein **Beispiel-Foto** des Aufbaus:
    - Folge der [offiziellen Anleitung](https://www.openhab.org/docs/installation/).
 
 2. **MQTT-Binding installieren**
-   - Gehe zu **Paper UI → Add-ons → Bindings**.
-   - Suche nach **MQTT Binding** und installiere es.
+   - Gehe zu **Add-ons → Bindings → MQTT Binding** und installiere es.
 
 3. **MQTT-Broker konfigurieren**
-   - Bearbeite die Datei **`/etc/openhab/services/mqtt.cfg`**:
+   Seit v3.3.0 verwendet der Controller ausschließlich **Home Assistant MQTT Discovery**.
+   openHAB unterstützt HA Discovery nicht nativ, daher müssen die MQTT-Things manuell
+   konfiguriert werden.
 
-   ```ini
-   broker.url=tcp://192.168.1.50:1883
-   broker.user=mqtt_user
-   broker.password=secret
-   ```
+   - Füge den MQTT-Broker in openHAB hinzu (**Einstellungen → Things → `+` → MQTT Broker**).
+   - Erstelle ein **neues Thing** aus dem MQTT-Binding und abonniere das Topic `homeassistant/#`.
 
    - Starte openHAB neu:
 
@@ -380,8 +378,11 @@ Hier ist ein **Beispiel-Foto** des Aufbaus:
      sudo systemctl restart openhab
      ```
 
-4. **Pool Controller manuell einrichten**
-   - Da der Controller **keine Homie-Unterstützung mehr hat** (ab v3.3.0), musst du die Geräte **manuell** einrichten.
+4. **Pool Controller einrichten**
+   - Nachdem der Broker konfiguriert ist, sollten die Entitäten des Controllers automatisch
+     unter `homeassistant/#` auffindbar sein.
+   - Falls nicht, können die Things manuell erstellt werden, indem die einzelnen
+     State/Command-Topics abonniert werden.
    - **Beispiel-Konfiguration:**
      - [openHAB-Konfiguration für Pool Controller](https://github.com/smart-swimmingpool/openhab-config)
 

--- a/docs/users-guide.de.md
+++ b/docs/users-guide.de.md
@@ -230,15 +230,20 @@ ohne manuelle Konfiguration.
 
 ## openHAB-Integration
 
-Der **Smart Swimmingpool Controller** kann seit Version 2.4 in [openHAB](https://www.openhab.org) integriert werden.
+Seit v3.3.0 verwendet der Controller ausschließlich **Home Assistant MQTT Discovery** —
+die bisherige Homie-Protokoll-Unterstützung wurde entfernt. openHAB unterstützt HA Discovery
+nicht nativ, daher müssen die MQTT-Things manuell konfiguriert werden.
 
-Es ist möglich, mit dem Controller zu interagieren, um die Pumpe ein-/auszuschalten oder die aktuelle Regel zu wechseln.
+Alle Controller-Entitäten werden als einfache MQTT-Topics unter
+`homeassistant/<component>/pool-controller/<object-id>/` veröffentlicht. In openHAB
+können sie als **MQTT Things** hinzugefügt werden, indem die entsprechenden
+State/Command-Topics abonniert werden.
 
-Auch die aktuellen Temperatur- oder Zustandswerte können überwacht werden.
+Die Entity-Referenz und Topic-Struktur findest du auf der Seite
+[MQTT-Konfiguration](../mqtt-configuration).
 
-Schließlich können auch die [Einstellungen](#einstellungen) aktualisiert werden.
-
-- TODO: Beispiel für openHAB-Konfiguration hinzufügen.
+Beispiele für openHAB-Konfigurationen gibt es im
+[openHAB Configuration Guide](https://github.com/smart-swimmingpool/openhab-config).
 
 ### Gerät
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -225,15 +225,19 @@ without any manual configuration.
 
 ## OpenHAB Integration
 
-The **Smart Swimmingpool Controller** could be integrated in [openHAB](https://www.openhab.org) since version 2.4.
+Since v3.3.0 the controller uses **Home Assistant MQTT Discovery** exclusively — the former
+Homie protocol support has been removed. openHAB does not support HA Discovery natively,
+so you need to configure the MQTT Things manually.
 
-It is possible to interact with the controller to enable/disable the pump or to switch the current rule.
+All controller entities are published as plain MQTT topics under
+`homeassistant/<component>/pool-controller/<object-id>/`. You can add them in openHAB
+as **MQTT Things** by subscribing to the relevant state/command topics.
 
-Also it is possible to monitor the current values of temperatures or states.
+See the entity reference and topic structure in the
+[MQTT Configuration](../mqtt-configuration) page.
 
-At least the [settings](#settings) could be updated, too.
-
-- TODO: add example of openhab config.
+Ready-to-use openHAB configuration examples are available in the
+[openHAB Configuration Guide](https://github.com/smart-swimmingpool/openhab-config).
 
 ### Device
 


### PR DESCRIPTION
## Summary

Since v3.3.0 the controller uses **Home Assistant MQTT Discovery** exclusively — the Homie protocol has been removed. openHAB does not support HA Discovery natively, so users need to manually configure MQTT Things.

## Changes

| File | Change |
|---|---|
| `docs/users-guide.md` | Rewrote openHAB section: explains manual MQTT Things config, points to openhab-config repo |
| `docs/users-guide.de.md` | Same in German |
| `docs/quick-start.md` | Modernized openHAB Option B: openHAB 3+ UI-based MQTT broker setup instead of old openHAB2 `mqtt.cfg` |
| `docs/quickstart.md` | Same in German |
| `docs/_index.md` | Added "(manual configuration required)" note |
| `docs/_index.de.md` | Added "(manuelle Konfiguration erforderlich)" note |

## Related

- openHAB example configs: https://github.com/smart-swimmingpool/openhab-config