### PR TITLE
Add WiFi status icon to NORVI display

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Enable auto-merge via gh CLI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -859,6 +859,24 @@ void NorviOledDisplay::drawFooter() {
     display.print(F("--:--"));
   }
 
+  // Draw WiFi status icon at position 64
+  if (NetworkManager::isWiFiConnected()) {
+    // WiFi connected icon (3 vertical bars with decreasing height)
+    dspFillRect(64, 56, 2, 8, SSD1306_WHITE);
+    dspFillRect(67, 56, 2, 6, SSD1306_WHITE);
+    dspFillRect(70, 56, 2, 4, SSD1306_WHITE);
+    dspFillRect(73, 56, 2, 2, SSD1306_WHITE);
+  } else {
+    // WiFi disconnected icon (X over the WiFi symbol)
+    dspFillRect(64, 56, 2, 8, SSD1306_WHITE);
+    dspFillRect(67, 56, 2, 6, SSD1306_WHITE);
+    dspFillRect(70, 56, 2, 4, SSD1306_WHITE);
+    dspFillRect(73, 56, 2, 2, SSD1306_WHITE);
+    // Draw X
+    dspHLine(64, 60, 10, SSD1306_WHITE);
+    dspVLine(70, 56, 4, SSD1306_WHITE);
+  }
+
   // ── Firmware version ──────────────────────────────────────────────────
   dspCursor(76, 56);
   display.print(F("v" FW_VERSION));


### PR DESCRIPTION
## Summary
- Added WiFi status icon to NORVI OLED display footer
- Icon displays on all pages between time and firmware version
- Shows 4 vertical bars when WiFi is connected
- Shows 4 vertical bars with X overlay when WiFi is disconnected

## Implementation Details
- Modified `NorviOledDisplay::drawFooter()` in `src/NorviOledDisplay.cpp`
- Uses existing `NetworkManager::isWiFiConnected()` API
- Icon positioned at (64, 56) on the 128x64 display
- Uses the existing `dspFillRect`, `dspHLine`, and `dspVLine` helper functions

## Verification
- Code compiles with existing dependencies
- Uses only existing APIs and helper functions
- Maintains consistent style with existing display code
