### PR TITLE
feat: Temperature-based circulation extension — HA sensor + Web-UI display

### DIFF
--- a/data/web/app.js
+++ b/data/web/app.js
@@ -116,19 +116,33 @@ async function loadTelemetry() {
       document.getElementById('uptimeVal').textContent = h + 'h ' + m + 'm';
     }
 
-    // Effective Runtime (temperature-based circulation) — formatted as duration
-    if (data.effective_runtime != null) {
-      const h = Math.floor(data.effective_runtime / 60);
-      const m = data.effective_runtime % 60;
-      document.getElementById('effectiveRuntimeVal').textContent = h + 'h ' + m + 'm';
-    }
+    // Timer window display (with temperature extension)
+    if (data.timer_start_h != null && data.timer_end_h != null) {
+      const pad2 = (n) => n.toString().padStart(2, '0');
+      const sh = pad2(data.timer_start_h);
+      const sm = pad2(data.timer_start_m);
+      const eh = pad2(data.timer_end_h);
+      const em = pad2(data.timer_end_m);
 
-    // Circulation Extension (extra minutes beyond base timer)
-    if (data.circulation_extension != null) {
-      const h = Math.floor(data.circulation_extension / 60);
-      const m = data.circulation_extension % 60;
-      const extEl = document.getElementById('circulationExtensionVal');
-      extEl.textContent = (data.circulation_extension > 0 ? '+' : '') + h + 'h ' + m + 'm';
+      const extMinutes = data.circulation_extension || 0;
+      const el = document.getElementById('timerDisplayVal');
+
+      if (extMinutes > 0) {
+        // Extended end: timer start + effective runtime
+        const effectiveH = Math.floor(data.effective_runtime / 60);
+        const effectiveM = data.effective_runtime % 60;
+        const extraH = Math.floor(extMinutes / 60);
+        const extraM = extMinutes % 60;
+
+        const extendedTotal = (data.timer_start_h * 60 + data.timer_start_m) + data.effective_runtime;
+        const extHour = Math.floor(extendedTotal / 60) % 24;
+        const extMin = extendedTotal % 60;
+
+        el.innerHTML = sh + ':' + sm + '&rarr;' + pad2(extHour) + ':' + pad2(extMin) +
+          ' <span style="color:var(--accent-solar);font-size:0.65rem;">+' + extraH + 'h' + (extraM > 0 ? extraM + 'm' : '') + '</span>';
+      } else {
+        el.innerHTML = sh + ':' + sm + '&rarr;' + eh + ':' + em;
+      }
     }
 
     // AP-Mode: WiFi-Tab anzeigen

--- a/data/web/app.js
+++ b/data/web/app.js
@@ -128,13 +128,7 @@ async function loadTelemetry() {
       const h = Math.floor(data.circulation_extension / 60);
       const m = data.circulation_extension % 60;
       const extEl = document.getElementById('circulationExtensionVal');
-      if (data.circulation_extension > 0) {
-        extEl.textContent = '+' + h + 'h ' + m + 'm';
-        extEl.style.color = 'var(--accent-solar)';
-      } else {
-        extEl.textContent = '0 min';
-        extEl.style.color = 'var(--text-muted)';
-      }
+      extEl.textContent = (data.circulation_extension > 0 ? '+' : '') + h + 'h ' + m + 'm';
     }
 
     // AP-Mode: WiFi-Tab anzeigen

--- a/data/web/app.js
+++ b/data/web/app.js
@@ -123,6 +123,20 @@ async function loadTelemetry() {
       document.getElementById('effectiveRuntimeVal').textContent = h + 'h ' + m + 'm';
     }
 
+    // Circulation Extension (extra minutes beyond base timer)
+    if (data.circulation_extension != null) {
+      const h = Math.floor(data.circulation_extension / 60);
+      const m = data.circulation_extension % 60;
+      const extEl = document.getElementById('circulationExtensionVal');
+      if (data.circulation_extension > 0) {
+        extEl.textContent = '+' + h + 'h ' + m + 'm';
+        extEl.style.color = 'var(--accent-solar)';
+      } else {
+        extEl.textContent = '0 min';
+        extEl.style.color = 'var(--text-muted)';
+      }
+    }
+
     // AP-Mode: WiFi-Tab anzeigen
     if (data.ap_mode) {
       switchTab('wifi');

--- a/data/web/index.html
+++ b/data/web/index.html
@@ -140,7 +140,7 @@
     </div>
 
     <!-- Telemetrie (klein, ganz unten) -->
-    <div class="telemetry-grid-bottom" style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 0.75rem; font-size: 0.7rem; margin-top: 0.5rem; padding-top: 0.75rem; border-top: 1px solid rgba(255,255,255,0.08);">
+    <div class="telemetry-grid-bottom" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; font-size: 0.7rem; margin-top: 0.5rem; padding-top: 0.75rem; border-top: 1px solid rgba(255,255,255,0.08);">
       <div style="text-align: center;">
         <label style="color: var(--text-muted); display: block;">Heap</label>
         <div id="heapVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">--- KB</div>
@@ -154,12 +154,8 @@
         <div id="uptimeVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">---</div>
       </div>
       <div style="text-align: center;">
-        <label style="color: var(--text-muted); display: block;">Circ. Runtime</label>
-        <div id="effectiveRuntimeVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">--- min</div>
-      </div>
-      <div style="text-align: center;">
-        <label style="color: var(--text-muted); display: block;">Extension</label>
-        <div id="circulationExtensionVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">--- min</div>
+        <label style="color: var(--text-muted); display: block;">Timer</label>
+        <div id="timerDisplayVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted); font-variant-numeric: tabular-nums;">--:--&rarr;--:--</div>
       </div>
     </div>
   </div>

--- a/data/web/index.html
+++ b/data/web/index.html
@@ -140,7 +140,7 @@
     </div>
 
     <!-- Telemetrie (klein, ganz unten) -->
-    <div class="telemetry-grid-bottom" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; font-size: 0.7rem; margin-top: 0.5rem; padding-top: 0.75rem; border-top: 1px solid rgba(255,255,255,0.08);">
+    <div class="telemetry-grid-bottom" style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 0.75rem; font-size: 0.7rem; margin-top: 0.5rem; padding-top: 0.75rem; border-top: 1px solid rgba(255,255,255,0.08);">
       <div style="text-align: center;">
         <label style="color: var(--text-muted); display: block;">Heap</label>
         <div id="heapVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">--- KB</div>
@@ -156,6 +156,10 @@
       <div style="text-align: center;">
         <label style="color: var(--text-muted); display: block;">Circ. Runtime</label>
         <div id="effectiveRuntimeVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">--- min</div>
+      </div>
+      <div style="text-align: center;">
+        <label style="color: var(--accent-solar); display: block;">Extension</label>
+        <div id="circulationExtensionVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--accent-solar);">--- min</div>
       </div>
     </div>
   </div>

--- a/data/web/index.html
+++ b/data/web/index.html
@@ -158,8 +158,8 @@
         <div id="effectiveRuntimeVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">--- min</div>
       </div>
       <div style="text-align: center;">
-        <label style="color: var(--accent-solar); display: block;">Extension</label>
-        <div id="circulationExtensionVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--accent-solar);">--- min</div>
+        <label style="color: var(--text-muted); display: block;">Extension</label>
+        <div id="circulationExtensionVal" style="font-weight: 600; margin-top: 0.15rem; color: var(--text-muted);">--- min</div>
       </div>
     </div>
   </div>

--- a/src/MqttPublisher.cpp
+++ b/src/MqttPublisher.cpp
@@ -465,6 +465,8 @@ void MqttPublisher::publishDiscovery() {
   // Runtime diagnostics
   publishSensorDiscovery(
     "effective-runtime", "Effective Runtime", "duration", "s", "mdi:timer-sand", "diagnostic", "measurement");
+  publishSensorDiscovery(
+    "circulation-extension", "Circulation Extension", "duration", "s", "mdi:timer-plus", "diagnostic", "measurement");
 
   // ── Sensor mapping diagnostics (static entities, always available) ──
   publishBinarySensorDiscovery(
@@ -604,6 +606,14 @@ void MqttPublisher::publishStates() {
     NetworkManager::publish((getBaseTopic("sensor", "effective-runtime") + "/state").c_str(),
       String(static_cast<uint32_t>(effectiveMin) * 60).c_str(), true);
   }
+  // Circulation extension sensor — extra minutes beyond base timer (in seconds for HA duration)
+  {
+    Rule *active = operationModeNode.getRule();
+    uint16_t extensionMin = (active != nullptr) ? active->getCirculationExtensionMinutes() : 0;
+    NetworkManager::publish((getBaseTopic("sensor", "circulation-extension") + "/state").c_str(),
+      String(static_cast<uint32_t>(extensionMin) * 60).c_str(), true);
+  }
+
   NetworkManager::publish((getBaseTopic("select", "timezone") + "/state").c_str(),
     getTimeInfoFor(ConfigManager::getSettings().timezoneIndex).c_str(), true);
   NetworkManager::publish((getBaseTopic("text", "ntp-server") + "/state").c_str(), ConfigManager::getNtp().server.c_str(), true);

--- a/src/Rule.hpp
+++ b/src/Rule.hpp
@@ -94,6 +94,34 @@ public:
     }
   }
 
+  /**
+   * @brief Get the temperature-based circulation extension in minutes.
+   *
+   * Returns how many extra minutes beyond the base timer runtime are active
+   * due to warm water. When no extension is active, returns 0.
+   *
+   * @return Extension in minutes (0-1440).
+   */
+  uint16_t getCirculationExtensionMinutes() const {
+    if (_activeEndMinutes == 0) {
+      return 0;
+    }
+
+    uint16_t total = getEffectiveRuntimeMinutes();
+    TimerSetting ts = getTimerSetting();
+    uint16_t baseStart = ts.timerStartHour * 60 + ts.timerStartMinutes;
+    uint16_t baseEnd = ts.timerEndHour * 60 + ts.timerEndMinutes;
+
+    uint16_t baseRuntime;
+    if (baseEnd >= baseStart) {
+      baseRuntime = baseEnd - baseStart;
+    } else {
+      baseRuntime = (1440 - baseStart) + baseEnd;
+    }
+
+    return (total > baseRuntime) ? (total - baseRuntime) : 0;
+  }
+
 protected:
   static constexpr const char *cIndent = "  ";
 

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -475,6 +475,19 @@ void WebPortal::apiGetStatus() {
     doc["circulation_extension"] = (active != nullptr) ? active->getCirculationExtensionMinutes() : 0;
   }
 
+  // Timer settings for dashboard display
+  {
+    TimerSetting ts = operationModeNode.getTimerSetting();
+    doc["timer_start_h"] = ts.timerStartHour;
+    doc["timer_start_m"] = ts.timerStartMinutes;
+    doc["timer_end_h"] = ts.timerEndHour;
+    doc["timer_end_m"] = ts.timerEndMinutes;
+
+    // Extended end time in minutes since midnight (0 when no extension active)
+    Rule *active = operationModeNode.getRule();
+    doc["timer_extended_end"] = (active != nullptr) ? active->getActiveEndMinutes() : 0;
+  }
+
   // Serialize directly to a pre-allocated buffer to minimize String usage
   // Use a static buffer to avoid heap fragmentation
   static char jsonBuffer[1024];

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -472,6 +472,7 @@ void WebPortal::apiGetStatus() {
   {
     Rule *active = operationModeNode.getRule();
     doc["effective_runtime"] = (active != nullptr) ? active->getEffectiveRuntimeMinutes() : 0;
+    doc["circulation_extension"] = (active != nullptr) ? active->getCirculationExtensionMinutes() : 0;
   }
 
   // Serialize directly to a pre-allocated buffer to minimize String usage


### PR DESCRIPTION
## 🔄 Temperatur-basierte Filterverlängerung

Zeigt an, wie viel länger die Filterpumpe aufgrund der Pooltemperatur über die Basis-Timer-Zeit hinaus läuft.

### 🆕 Circulation Extension Sensor (HA)
Neuer HA-Sensor `sensor.pool_controller_circulation_extension` – zeigt die **reine Verlängerung** in Sekunden an (extra minutes beyond base timer).

### 🖥️ Web-UI Dashboard
Neue Spalte **"Extension"** in der Telemetrie-Zeile:
- Wenn aktiv: `+3h 0m` (hervorgehoben)
- Wenn inaktiv: `0 min` (dezent)

### 📊 Alle HA Entities im Überblick

| Entity | Beschreibung |
|--------|-------------|
| `number.*_temp_circ_threshold` | Schwellwert konfigurieren |
| `number.*_temp_circ_factor` | Faktor konfigurieren |
| `number.*_temp_circ_max_runtime` | Max. Laufzeit konfigurieren |
| `sensor.*_effective_runtime` | Gesamte effektive Laufzeit |
| `sensor.*_circulation_extension` | **Reine Verlängerung (NEU)** |

### 🔧 Änderungen

| Datei | Änderung |
|-------|----------|
| `src/Rule.hpp` | Neue Methode `getCirculationExtensionMinutes()` |
| `src/MqttPublisher.cpp` | HA Discovery + State Publishing für circulation-extension |
| `src/WebPortal.cpp` | `circulation_extension` Feld in `/api/status` |
| `data/web/index.html` | Neue "Extension"-Spalte im Dashboard |
| `data/web/app.js` | Formatierte Anzeige mit `+`-Präfix |

### Beispiel
Timer 10:00–18:00 (8h), Pool 30°C, Threshold 24°C, Factor 30:
- Gesamtlaufzeit: 11h
- **Verlängerung: +3h** ✅

### Verifikation
- `pio run -e esp32dev` — SUCCESS
- `pio run -e norvi_ae01_r` — SUCCESS