### PR TITLE
docs: NORVI Display Bedien- und Navigationskonzept

### DIFF
--- a/docs/norvi-display-navigation-concept.de.md
+++ b/docs/norvi-display-navigation-concept.de.md
@@ -1,7 +1,7 @@
 # Bedien- und Navigationskonzept — NORVI IIOT-AE01-R OLED + 3 Tasten
 
-> **Status:** Konzept / RFC  
-> **Ziel:** Verbesserung der UX des 128×64 OLED-Displays mit den drei Fronttasten (S1/S2/S3)  
+> **Status:** Konzept / RFC
+> **Ziel:** Verbesserung der UX des 128×64 OLED-Displays mit den drei Fronttasten (S1/S2/S3)
 > **Behandelt:** Button-Mapping, Bildschirm-Hierarchie, Hints, Wizard-Navigation, Sonderfälle
 
 ---
@@ -71,7 +71,7 @@ Beide Tasten zeigen auf normalen Seiten das Label `nxt`. Damit ist nicht ersicht
 | **S2** | ▼ | Nächste Seite | Nächste Option | — (nicht belegt) |
 | **S3** | ● | Aktion / Enter (siehe Seite) | Bestätigen / Weiter | Kontext-Aktion (speichern, reboot) |
 
-S1 und S2 sind **immer** Navigation — egal ob zwischen Seiten oder innerhalb eines Wizards.  
+S1 und S2 sind **immer** Navigation — egal ob zwischen Seiten oder innerhalb eines Wizards.
 S3 ist **immer** die Aktionstaste — was sie tut, steht im Hint-Label.
 
 ### 4.2 Hint-Labels pro Seite
@@ -339,8 +339,8 @@ Spalte:  98     108    118    128
 
 ### 8.3 Wizard-Cancel / Rückzug
 
-Im Sensor-Wizard gibt es aktuell keinen Weg zurück, außer abzubrechen (Timeout).  
-**Vorschlag:** S1 auf der ersten Wizard-Stufe (SELECT_SENSOR) zeigt `back`, wenn `setupSelectedDev_ == 0` und der Nutzer nochmal S1 drückt → zurück zu IDLE.  
+Im Sensor-Wizard gibt es aktuell keinen Weg zurück, außer abzubrechen (Timeout).
+**Vorschlag:** S1 auf der ersten Wizard-Stufe (SELECT_SENSOR) zeigt `back`, wenn `setupSelectedDev_ == 0` und der Nutzer nochmal S1 drückt → zurück zu IDLE.
 (Das erfordert minimale Logik-Änderung in `setupSelectPrevious()`.)
 
 ### 8.4 Long-Press-Modell

--- a/docs/norvi-display-navigation-concept.de.md
+++ b/docs/norvi-display-navigation-concept.de.md
@@ -1,8 +1,10 @@
 # Bedien- und Navigationskonzept — NORVI IIOT-AE01-R OLED + 3 Tasten
 
-> **Status:** Konzept / RFC  
-> **Ziel:** Verbesserung der UX des 128×64 OLED-Displays mit den drei Fronttasten (S1/S2/S3)  
-> **Behandelt:** Button-Mapping, Bildschirm-Hierarchie, Hints, Wizard-Navigation, Sonderfälle
+> **Status:** Konzept / RFC (Review v1.1, Juli 2026)  
+> **Ziel:** Verbesserung der UX des 128×64 OLED-Displays mit den drei
+> Fronttasten (S1/S2/S3)  
+> **Behandelt:** Button-Mapping, Bildschirm-Hierarchie, Hints,
+> Wizard-Navigation, Long-Press-Feedback, Sonderfälle
 
 ---
 
@@ -13,8 +15,10 @@
   - **S1 (oben)** — ▲
   - **S2 (Mitte)** — ▼
   - **S3 (unten)** — ●
-- **Tasten-Interface:** Resistor-Ladder an GPIO32 (ADC), kein Interrupt — Polling alle 50 ms
-- **Long-Press:** Erkennung nach >2 s, kann Short-Press konsumieren (Callback-Rückgabe `true`)
+- **Tasten-Interface:** Resistor-Ladder an GPIO32 (ADC), kein Interrupt
+  — Polling alle 50 ms
+- **Long-Press:** Erkennung nach >2 s, kann Short-Press konsumieren
+  (Callback-Rückgabe `true`)
 
 ---
 
@@ -24,40 +28,55 @@
 
 | Kontext | S3-Kurz (aktuell) | Problem |
 |---------|-------------------|---------|
-| MAIN    | Betriebsmodus cyclen (auto→manu→boost→timer) | Ein Tastendruck ändert unumkehrbar den Betriebsmodus. Ein versehentlicher Druck während des Vorbeiscrollens schaltet von `auto` auf `manu` — die Pumpe läuft dann dauerhaft. |
-| Andere Infoseiten | Betriebsmodus cyclen | Der Nutzer erwartet auf PAGE 3 (QRCODE) keine Modus-Änderung. |
+| MAIN | Betriebsmodus cyclen (auto→manu→boost→timer) | Ein Tastendruck ändert unumkehrbar den Betriebsmodus. Ein versehentlicher Druck während des Vorbeiscrollens schaltet von `auto` auf `manu` — die Pumpe läuft dann dauerhaft. |
+| Andere Infoseiten | Betriebsmodus cyclen | Der Nutzer erwartet auf QRCODE keine Modus-Änderung. |
 | SENSOR_SETUP | Wizard-Advance | Einziger Kontext, in dem S3 sinnvoll ist. |
 
-**➜ S3 darf auf Infoseiten keine Seiteneffekte haben, die den Anlagenbetrieb verändern.**
+**➜ S3 darf auf Infoseiten keine Seiteneffekte haben,
+die den Anlagenbetrieb verändern.**
 
 ### 2.2 Hint-Labels „nxt" für S1 und S2
 
-Beide Tasten zeigen auf normalen Seiten das Label `nxt`. Damit ist nicht ersichtlich, dass S1 **zurück** und S2 **vor** blättert. Der Nutzer muss durch Trial & Error herausfinden, welche Taste wohin navigiert.
+Beide Tasten zeigen auf normalen Seiten das Label `nxt`. Damit ist nicht
+ersichtlich, dass S1 **zurück** und S2 **vor** blättert. Der Nutzer muss
+durch Trial & Error herausfinden, welche Taste wohin navigiert.
 
 ### 2.3 Fehlende visuelle Hierarchie
 
 - Keine Unterscheidung zwischen „Info-Seiten" und „Interaktions-Seiten"
-- Kein Hinweis, dass man sich auf Seite X von Y befindet (nur eine nackte Zahl rechts unten)
-- Kein „Exit"- oder „Back"-Gefühl — einmal im Sensor-Wizard steckt man fest, bis man entweder fertig ist oder 60 s gewartet hat
+- Kein Hinweis, dass man sich auf Seite X von Y befindet (nur eine nackte
+  Zahl rechts unten)
+- Kein „Exit"- oder „Back"-Gefühl — einmal im Sensor-Wizard steckt man fest,
+  bis man entweder fertig ist oder 60 s gewartet hat
 
 ### 2.4 Long-Press ist unsichtbar
 
-- S3 lang speichert Sensor-Mapping und rebootet — aber der Nutzer sieht das nirgends, solange nicht beide Sensoren zugewiesen sind.
-- Es gibt kein konsistentes Long-Press-Modell, das der Nutzer lernen und erwarten kann.
+- S3 lang speichert Sensor-Mapping und rebootet — aber der Nutzer sieht das
+  nirgends, solange nicht beide Sensoren zugewiesen sind.
+- Es gibt kein konsistentes Long-Press-Modell, das der Nutzer lernen und
+  erwarten kann.
+- **Keine visuelle Rückmeldung** während des Haltens — der Nutzer weiß nicht,
+  ob der Druck registriert wurde oder wie lange er noch halten muss.
 
 ### 2.5 Auto-Return ohne Vorwarnung
 
-- Nach 60 s springt das Display unhinterfragt zurück zu MAIN — das kann mitten im Lesen einer IP-Adresse passieren.
+- Nach 60 s springt das Display unhinterfragt zurück zu MAIN — das kann
+  mitten im Lesen einer IP-Adresse passieren.
 
 ---
 
 ## 3. Design-Prinzipien
 
-1. **Konsistenz:** Jede Taste hat eine gleichbleibende Grundbedeutung (S1=▲=rauf/zurück, S2=▼=runter/vor, S3=●=Aktion/bestätigen).
-2. **Sicherheit:** Keine Taste ändert den Anlagenzustand ohne explizite Bestätigung oder klares Label.
-3. **Sichtbarkeit:** Jede Taste hat ein kontextspezifisches, eindeutiges Hint-Label.
-4. **Minimale Überraschung:** Keine Side-Effects beim Scrollen. Aktionen sind explizit.
-5. **Fat-Finger-freundlich:** Wichtige Aktionen erfordern zwei Schritte oder Long-Press.
+1. **Konsistenz:** Jede Taste hat eine gleichbleibende Grundbedeutung
+   (S1=▲=rauf/zurück, S2=▼=runter/vor, S3=●=Aktion/bestätigen).
+2. **Sicherheit:** Keine Taste ändert den Anlagenzustand ohne explizite
+   Bestätigung oder klares Label.
+3. **Sichtbarkeit:** Jede Taste hat ein kontextspezifisches, eindeutiges
+   Hint-Label. Long-Press wird visuell begleitet.
+4. **Minimale Überraschung:** Keine Side-Effects beim Scrollen. Aktionen
+   sind explizit.
+5. **Fat-Finger-freundlich:** Wichtige Aktionen erfordern zwei Schritte
+   oder Long-Press mit Fortschrittsanzeige.
 
 ---
 
@@ -71,13 +90,14 @@ Beide Tasten zeigen auf normalen Seiten das Label `nxt`. Damit ist nicht ersicht
 | **S2** | ▼ | Nächste Seite | Nächste Option | — (nicht belegt) |
 | **S3** | ● | Aktion / Enter (siehe Seite) | Bestätigen / Weiter | Kontext-Aktion (speichern, reboot) |
 
-S1 und S2 sind **immer** Navigation — egal ob zwischen Seiten oder innerhalb eines Wizards.  
+S1 und S2 sind **immer** Navigation — egal ob zwischen Seiten oder
+innerhalb eines Wizards.  
 S3 ist **immer** die Aktionstaste — was sie tut, steht im Hint-Label.
 
 ### 4.2 Hint-Labels pro Seite
 
-| Seite | S1-Hint | S2-Hint | S3-Hint | S3-Lang |
-|-------|---------|---------|---------|---------|
+| Seite | S1 | S2 | S3 | S3-Lang |
+|-------|----|----|----|---------|
 | MAIN | — | next | menu | — |
 | NETWORK | prev | next | — | — |
 | SYSTEM | prev | next | — | — |
@@ -89,8 +109,30 @@ S3 ist **immer** die Aktionstaste — was sie tut, steht im Hint-Label.
 
 **Änderungen:**
 - S1 zeigt `prev` statt `nxt` — eindeutig anders als S2 (`next`)
-- S3 zeigt **nie** `ok` auf Infoseiten, sondern ist entweder leer (keine Aktion) oder zeigt klar, was passiert (`menu`, `setup`, `select`, `assign`)
+- S3 zeigt **nie** `ok` auf Infoseiten, sondern ist entweder leer (keine
+  Aktion) oder zeigt klar, was passiert (`menu`, `setup`, `select`,
+  `assign`)
 - MAIN-Seite: S3 öffnet ein Aktionsmenü statt direkt den Modus zu wechseln
+
+### 4.3 Internationalisierung (i18n)
+
+Die Label sind bewusst kurz (max. 10 Zeichen), damit sie in die 30px
+rechte Spalte passen. Alternativvorschläge pro Sprache:
+
+| EN (Default) | DE | FR | Zweck |
+|-------------|----|----|-------|
+| prev | zurück | préc | Rückwärts |
+| next | vor | suiv | Vorwärts |
+| menu | menü | menu | Aktionen öffnen |
+| setup | einr | conf | Wizard starten |
+| select | wahl | choix | Auswahl bestätigen |
+| assign | setz | attr | Rolle zuweisen |
+| save | spei | save | Speichern |
+
+**Entscheidung:** Vorerst EN (geringster Speicherverbrauch, keine
+zusätzliche Übersetzungslogik). Eine i18n-Erweiterung kann später
+über PROGMEM-String-Tabellen nachgerüstet werden, falls das Display
+auch in nicht-englischen Kontexten eingesetzt wird.
 
 ---
 
@@ -124,11 +166,12 @@ S3 ist **immer** die Aktionstaste — was sie tut, steht im Hint-Label.
 │  (erreichbar via S3 auf Seite       │
 │   SENSOR_SETUP)                     │
 │                                     │
-│  Step 1: SELECT_SENSOR              │
+│  Step 1/2: SELECT_SENSOR            │
 │  S1/S2 = up/dn (Sensor wählen)      │
 │  S3    = select (bestätigen)        │
+│  S1 am Ende → cancel               │
 │                                     │
-│  Step 2: SELECT_ROLE                │
+│  Step 2/2: SELECT_ROLE              │
 │  S1/S2 = up/dn (Solar/Pool)         │
 │  S3    = assign (zuweisen)          │
 │                                     │
@@ -151,7 +194,7 @@ S3 ist **immer** die Aktionstaste — was sie tut, steht im Hint-Label.
 │ ○ 19.1°C             │ S3 ●│ menu
 │ Solar                │      │
 ├──────────────────────┴──────┤
-│ AUTO  12:30  v2.1.0     1  │
+│ AUTO  12:30  v2.1.0     1/5│
 └─────────────────────────────┘
 ```
 
@@ -169,7 +212,7 @@ S3 ist **immer** die Aktionstaste — was sie tut, steht im Hint-Label.
 │ IP: 192.168.1.42     │ S3  │
 │ MQTT: CONNECTED      │      │
 ├──────────────────────┴──────┤
-│ AUTO  12:30  v2.1.0     2  │
+│ AUTO  12:30  v2.1.0     2/5│
 └─────────────────────────────┘
 ```
 
@@ -187,7 +230,7 @@ S3 ist **immer** die Aktionstaste — was sie tut, steht im Hint-Label.
 │ FW: v2.1.0           │      │
 │ Min: 98000 B         │      │
 ├──────────────────────┴──────┤
-│ AUTO  12:30  v2.1.0     3  │
+│ AUTO  12:30  v2.1.0     3/5│
 └─────────────────────────────┘
 ```
 
@@ -202,13 +245,14 @@ S3 ist **immer** die Aktionstaste — was sie tut, steht im Hint-Label.
 │ │  ██  ██  ██  │     │      │
 │ └──────────────┘     │      │
 ├──────────────────────┴──────┤
-│ AUTO  12:30  v2.1.0     4  │
+│ AUTO  12:30  v2.1.0     4/5│
 └─────────────────────────────┘
 ```
 
 ### 6.5 WIFI_SETUP — Ersteinrichtung
 
-Identisch zu QRCODE im Layout, aber mit zusätzlichem Text zur WiFi-Einrichtung.
+Identisch zu QRCODE im Layout, aber mit zusätzlichem Text zur
+WiFi-Einrichtung.
 
 ### 6.6 Aktionsmenü (auf MAIN via S3)
 
@@ -220,45 +264,49 @@ Identisch zu QRCODE im Layout, aber mit zusätzlichem Text zur WiFi-Einrichtung.
 │                      │ S3 ●│ select
 │                      │      │
 ├──────────────────────┴──────┤
-│ AUTO  12:30  v2.1.0     1  │
+│ AUTO  12:30  v2.1.0     1/5│
 └─────────────────────────────┘
 ```
 
 | Menü-Eintrag | S3-Aktion |
 |-------------|-----------|
-| **Mode: auto** | Modus cyclen (auto→manu→boost→timer→auto) + sofort zurück zu MAIN |
+| **Mode: auto** | Modus cyclen + zurück zu MAIN |
 | **Pump: on/off** | Pumpe manuell ein/aus + zurück zu MAIN |
 | **→ Exit menu** | Zurück zu MAIN ohne Änderung |
 
 S1/S2 navigieren zwischen den Menüzeilen. S3 bestätigt die Auswahl.
 
 **Warum ein Menü statt direkter Modus-Cycle?**
-- Der Nutzer muss aktiv ins Menü gehen → kein versehentlicher Modus-Wechsel beim Blättern
+- Der Nutzer muss aktiv ins Menü gehen → kein versehentlicher Modus-Wechsel
+  beim Blättern
 - Das Label `menu` auf S3 ist eindeutig und erwartbar
-- Langfristig können hier weitere Aktionen ergänzt werden (Pumpe togglen, Relais-Status, Neustart)
+- Langfristig können hier weitere Aktionen ergänzt werden (Pumpe togglen,
+  Relais-Status, Neustart)
+- Trade-off: ein Klick mehr für den Modus-Wechsel — gerechtfertigt durch
+  die verhinderte Fehlbedienung
 
 ### 6.7 SENSOR_SETUP — Sensor-Zuordnungswizard
 
-**Step 1 — SELECT_SENSOR:**
+**Step 1/2 — SELECT_SENSOR (mit Schritt-Indikator):**
 
 ```
 ┌──────────────────────┬──────┐
-│ Sensor Setup         │      │
+│ Sensor Setup   [1/2] │      │
 │──────────────────────│ S1 ▲│ up
-│ ▓0: 28FFAABB  <-SOLAR│ S2 ▼│ dn
+│ ▓0: 28FFAABB  SOLAR  │ S2 ▼│ dn
 │   22.5°C        ◄    │ S3 ●│ select
 │ 1: 28FECD12          │      │
 │   19.1°C             │      │
 ├──────────────────────┴──────┤
-│ S1/S2=pick  S3=select       │
+│ S1/S2=pick  S3=sel  L=cancel│
 └─────────────────────────────┘
 ```
 
-**Step 2 — SELECT_ROLE:**
+**Step 2/2 — SELECT_ROLE:**
 
 ```
 ┌──────────────────────┬──────┐
-│ Sensor Setup         │      │
+│ Sensor Setup   [2/2] │      │
 │──────────────────────│ S1 ▲│ up
 │ 0: 28FFAABB  SOLAR   │ S2 ▼│ dn
 │ ┌──────────────────┐ │ S3 ●│ assign
@@ -267,7 +315,7 @@ S1/S2 navigieren zwischen den Menüzeilen. S3 bestätigt die Auswahl.
 │ │   Pool           │ │      │
 │ └──────────────────┘ │      │
 ├──────────────────────┴──────┤
-│ S1/S2=role  S3=assign       │
+│ S1/S2=role  S3=save  L=back│
 └─────────────────────────────┘
 ```
 
@@ -282,7 +330,7 @@ S1/S2 navigieren zwischen den Menüzeilen. S3 bestätigt die Auswahl.
 │                      │ S3  │
 │                      │  lang│ save+reboot
 ├──────────────────────┴──────┤
-│ Both set. Hold S3=Save      │
+│ ▓▓▓▓▓░░░ Hold S3=Save      │
 └─────────────────────────────┘
 ```
 
@@ -290,7 +338,10 @@ S1/S2 navigieren zwischen den Menüzeilen. S3 bestätigt die Auswahl.
 
 ## 7. Hint-Bar-Design (rechte Spalte)
 
-Die Hint-Bar nutzt die rechten ~30 Pixel (Spalten 98–127). Sie wird auf allen Info-Seiten gezeichnet.
+### 7.1 Layout
+
+Die Hint-Bar nutzt die rechten ~30 Pixel (Spalten 98–127). Sie wird auf
+allen Info-Seiten gezeichnet.
 
 ```
 Spalte:  98     108    118    128
@@ -309,60 +360,170 @@ Spalte:  98     108    118    128
          └──────┴──────┴──────┘
 ```
 
-**Gestaltungsregeln:**
+### 7.2 Gestaltungsregeln
+
 - S1 ist oben, S2 mitte, S3 unten — exakt wie die physikalische Anordnung
-- Das Label steht **links** vom Symbol, damit es gelesen wird bevor das Auge zum Symbol wandert
-- Wenn eine Taste keine Aktion hat, wird sie ausgeblendet (kein Text, kein Symbol)
+- Das Label steht **links** vom Symbol, damit es gelesen wird bevor das
+  Auge zum Symbol wandert
+- Wenn eine Taste keine Aktion hat, wird sie ausgeblendet (kein Text,
+  kein Symbol)
 - Symbole: ▲ (S1), ▼ (S2), ● (S3) — auch in der Lücke ohne Text erkennbar
 - Die Farbgebung bleibt monochrom (SSD1306_WHITE)
 
+### 7.3 Kontextsensitivität
+
+Die Hint-Bar zeigt **nur** die aktuell relevanten Aktionen:
+
+| Seite | Sichtbare Hints | Begründung |
+|-------|----------------|-----------|
+| MAIN | S2: next, S3: menu | S1 hat keine Funktion (erste Seite) |
+| NETWORK–QRCODE | S1: prev, S2: next | S3 hat keine Funktion auf Info-Seiten |
+| SENSOR_SETUP (aktiv) | S1: up, S2: dn, S3: select/assign | Wizard braucht alle drei |
+| Aktionsmenü | S1: ▲, S2: ▼, S3: select | Menü-Navigation + Bestätigung |
+
+### 7.4 Primary-Action-Hervorhebung
+
+Die primäre Aktion (S3) kann durch einen **invertierten Hintergrund**
+(ein gefülltes Rechteck hinter dem Label) hervorgehoben werden. Das
+entspricht der existierenden `dspInvertedText()`-Funktion und benötigt
+keine zusätzliche Farbe (OLED ist monochrom).
+
 ---
 
-## 8. Sonderfälle & Edge Cases
+## 8. Long-Press: Visuelles Feedback
 
-### 8.1 Erster Boot (kein WiFi / keine Sensor-Mapping)
+### 8.1 Problem
 
-- Display startet automatisch auf **WIFI_SETUP** oder **SENSOR_SETUP** (bereits implementiert)
-- Button-Verhalten ist identisch zu den normalen Seiten — S1/S2 blättern, S3 hat keine Aktion außer auf SENSOR_SETUP
-- Der Nutzer muss zwingend ins Web-Interface — das Display macht das klar („Scan QR or enter URL")
+Aktuell gibt es **null visuelle Rückmeldung** beim Long-Press. Der Nutzer
+hält S3 und weiß nicht, ob der Druck ankommt oder wie lange er noch halten
+muss. Das ist besonders kritisch bei der Aktion „save + reboot".
 
-### 8.2 Auto-Return-Timeouts
+### 8.2 Vorgeschlagenes Fortschritts-Banner
+
+Statt eines Countdowns (zu viel Text für 128×64) wird ein **horizontaler
+Fortschrittsbalken** unterhalb des Inhaltsbereichs, aber oberhalb des
+Footers eingeblendet:
+
+```
+┌──────────────────────┬──────┐
+│ Sensor Setup         │      │
+│──────────────────────│      │
+│ 0: 28FFAABB  SOLAR   │      │
+│ 1: 28FECD12  POOL    │      │
+│                      │      │
+│ ▓▓▓▓▓░░░░░ save...  │      │   <- Fortschritt (wächst über 2 s)
+├──────────────────────┴──────┤
+│ Hold S3 to save & reboot    │
+└─────────────────────────────┘
+```
+
+**Implementierung:**
+- Balkenlänge wächst von 0 % auf 100 % über 2000 ms (LONG_PRESS_MS)
+- Timer wird in der Display-loop() aktualisiert (forceRedraw während Press)
+- Bei Erreichen von 100 % → Aktion auslösen + reboot
+- Bei Loslassen vor 100 % → Balken verschwindet, keine Aktion
+
+### 8.3 Alternative: Invertiertes Label
+
+Bei sehr wenig Platz (z. B. im Aktionsmenü) reicht auch ein invertiertes
+S3-Hint-Label, das nach >1 s von `save` zu `SAVE!` wechselt:
+
+| Zeit | S3-Hint | Zustand |
+|------|---------|---------|
+| 0–1 s | save | Normal |
+| 1–2 s | SAVE! | Invertiert (highlighted) |
+| >2 s | Aktion feuert | — |
+
+### 8.4 Konsistentes Long-Press-Modell
+
+Long-Press wird nur für **kritische, bestätigungspflichtige Aktionen**
+genutzt und **immer** mit visuellem Feedback:
+
+- Sensor-Mapping speichern + Reboot
+- Zukünftig: Factory Reset, Safe Mode, Neustart
+
+Auf allen anderen Seiten hat S3-Lang keine Funktion (keine Überraschung).
+
+---
+
+## 9. Sonderfälle & Edge Cases
+
+### 9.1 Erster Boot (kein WiFi / keine Sensor-Mapping)
+
+- Display startet automatisch auf **WIFI_SETUP** oder **SENSOR_SETUP**
+  (bereits implementiert)
+- Button-Verhalten ist identisch zu den normalen Seiten — S1/S2 blättern,
+  S3 hat keine Aktion außer auf SENSOR_SETUP
+- Der Nutzer muss zwingend ins Web-Interface — das Display macht das klar
+
+### 9.2 Auto-Return-Timeouts
 
 | Zustand | Timeout | Ziel |
 |---------|---------|------|
 | Info-Seite (nicht MAIN) | 60 s | MAIN |
-| Aktionsmenü | 30 s | MAIN |
-| Sensor-Wizard (SELECT) | 120 s | IDLE+MAIN |
-| Sensor-Wizard (ROLE) | 120 s | IDLE+MAIN |
+| Aktionsmenü | 30 s | MAIN (Menü schließt sich) |
+| Sensor-Wizard (SELECT) | 120 s | IDLE + MAIN |
+| Sensor-Wizard (ROLE) | 120 s | IDLE + MAIN |
 
-- **Neu:** 5 s vor Auto-Return wird der Bildschirm nicht sofort umgeschaltet — stattdessen läuft das Menü einfach aus. Der Timeout wird nur **zwischen** Tastendrücken gemessen. Solange der Nutzer aktiv ist, passiert nichts.
+**Verhalten:**
+- Timeout wird nur **zwischen** Tastendrücken gemessen. Solange der Nutzer
+  aktiv ist, passiert nichts.
+- 5 s vor Auto-Return wird auf dem Display ein kurzer Hinweis eingeblendet:
+  z. B. `→ MAIN in 5s` rechts unten im Footer (blinkend).
 
-### 8.3 Wizard-Cancel / Rückzug
+### 9.3 Wizard-Cancel / Rückzug
 
-Im Sensor-Wizard gibt es aktuell keinen Weg zurück, außer abzubrechen (Timeout).  
-**Vorschlag:** S1 auf der ersten Wizard-Stufe (SELECT_SENSOR) zeigt `back`, wenn `setupSelectedDev_ == 0` und der Nutzer nochmal S1 drückt → zurück zu IDLE.  
-(Das erfordert minimale Logik-Änderung in `setupSelectPrevious()`.)
+Im Sensor-Wizard gibt es aktuell keinen Weg zurück.
 
-### 8.4 Long-Press-Modell
+**Vorschlag 1 — S1-Cancel (bevorzugt):**
+S1 auf der ersten Wizard-Stufe, wenn `setupSelectedDev_ == 0`, zeigt
+`back` und setzt bei nochmaligem Drücken auf IDLE zurück.
 
-Long-Press wird nur für **kritische, bestätigungspflichtige Aktionen** genutzt:
-- Sensor-Mapping speichern + Reboot
-- Zukünftig: Factory Reset, Safe Mode
+```cpp
+void NorviOledDisplay::setupSelectPrevious() {
+  if (setupSelectedDev_ == 0 && setupStep_ == SetupStep::SELECT_SENSOR) {
+    // Zurück zu IDLE
+    setupStep_ = SetupStep::IDLE;
+    setupSelectedDev_ = 0;
+    forceRedraw_ = true;
+    return;
+  }
+  // ... bestehende Logik ...
+}
+```
 
-Optimalerweise wird Long-Press auf S3 **auf allen Seiten** konsistent als „erweiterte Aktion" etabliert.
+**Vorschlag 2 — S1-Lang-Cancel (Alternative):**
+Falls S1-Kurz immer „vorherige Option" bleiben soll: S1 lang (>2 s) in
+SELECT_SENSOR bricht ab → zurück zu IDLE. Vorteil: kein unbeabsichtigter
+Cancel. Nachteil: inkonsistentes Long-Press-Modell (bisher nur S3).
 
-### 8.5 QR-Code-Seiten mit vollem Bildschirm
+**Entscheidung:** Vorschlag 1 (S1-Kurz am Ende der Liste). Einfach zu
+implementieren, intuitiv („weiter zurück geht nicht → zurück zum Start").
 
-Auf QRCODE und WIFI_SETUP wird die Hint-Bar aktuell ausgeblendet, um Platz für den QR-Code zu schaffen.
-Das ist akzeptabel, da der QR-Code die primäre Interaktion ist und der Nutzer auf diesen Seiten typischerweise nicht navigiert, sondern scannt.
+### 9.4 Schritt-Indikator im Wizard
+
+Der Wizard (SENSOR_SETUP) bekommt einen visuellen Schritt-Indikator:
+
+- **Vorschlag:** `[1/2]` und `[2/2]` rechts neben dem Titel in der
+  Titelzeile
+- **Alternativ:** Drei kleine Punkte `●○○` / `○●○` / `○○●` — aber bei nur
+  2 Schritten unnötig komplex
+- **Umsetzung:** Minimaler Platzbedarf (ca. 25 px in der oberen Zeile)
+
+### 9.5 QR-Code-Seiten ohne Hint-Bar
+
+Auf QRCODE und WIFI_SETUP wird die Hint-Bar ausgeblendet, um Platz für
+den QR-Code zu schaffen. Das ist akzeptabel, da der QR-Code die primäre
+Interaktion ist und der Nutzer auf diesen Seiten typischerweise nicht
+navigiert, sondern scannt.
 
 ---
 
-## 9. Umsetzungsplan (Code-Änderungen)
+## 10. Umsetzungsplan (Code-Änderungen)
 
-### 9.1 Hint-Labels korrigieren
+### PR 1: Hint-Labels + Footer (niedriges Risiko)
 
-**Dateien:** `NorviOledDisplay.cpp` — Funktion `drawButtonHints()`
+**Dateien:** `NorviOledDisplay.cpp` — `drawButtonHints()`, `drawFooter()`
 
 | Change | Aktuell | Neu |
 |--------|---------|-----|
@@ -370,19 +531,15 @@ Das ist akzeptabel, da der QR-Code die primäre Interaktion ist und der Nutzer a
 | S2-Label auf Info-Seiten | `nxt` | `next` |
 | S3 auf MAIN | `ok` | `menu` |
 | S3 auf NETWORK/SYSTEM/QRCODE/WIFI_SETUP | `ok` | leer (ausblenden) |
+| Footer Page-Zahl | `1`–`6` | `1/5`–`5/5` |
 
-### 9.2 S3-Modus-Cycle entfernen, Aktionsmenü einbauen
+### PR 2: Aktionsmenü + Wizard-Verbesserungen (mittleres Risiko)
 
-**Datei:** `PoolController.cpp` — Callback S3
+**Dateien:** `PoolController.cpp`, `NorviOledDisplay.{hpp,cpp}`
 
-Statt direktem Mode-Cycle:
-1. S3 auf MAIN → setzt internen `menuActive_`-Flag
-2. Display zeigt Menü-Overlay (3 Zeilen: Mode, Pump, Exit)
-3. S1/S2 navigieren im Menü
-4. S3 bestätigt Auswahl
-5. S3 (oder Exit) → zurück zu MAIN
+1. S3-Callback auf MAIN → setzt `menuActive_`-Flag statt Mode-Cycle
+2. Neue State-Machine in `NorviOledDisplay`:
 
-Separate kleine State-Machine in `NorviOledDisplay`:
 ```cpp
 enum class MenuItem : uint8_t {
   MODE,
@@ -393,35 +550,32 @@ static MenuItem menuSelection_;
 static bool menuActive_;
 ```
 
-### 9.3 Wizard-Cancel
+1. Menü-Zeichnung als eigener Draw-Zweig in `drawPage()`
+2. Wizard-Cancel in `setupSelectPrevious()` (siehe 9.3)
+3. Schritt-Indikator `[1/2]` / `[2/2]` im Wizard-Titel
 
-**Datei:** `NorviOledDisplay.cpp` — `setupSelectPrevious()`
+### PR 3: Long-Press-Feedback + Auto-Return-Warnung (mittleres Risiko)
 
-Wenn `setupSelectedDev_ == 0` und nochmal `previous()` → zurücksetzen auf IDLE.
+**Dateien:** `NorviButtonHandler.cpp`, `NorviOledDisplay.cpp`
+
+1. `NorviButtonHandler` exponiert Long-Press-Fortschritt:
 
 ```cpp
-void NorviOledDisplay::setupSelectPrevious() {
-  if (setupSelectedDev_ == 0 && setupStep_ == SetupStep::SELECT_SENSOR) {
-    // Back to IDLE
-    setupStep_ = SetupStep::IDLE;
-    forceRedraw_ = true;
-    return;
-  }
-  // ... existing logic ...
-}
+// In NorviButtonHandler.hpp
+/** @brief Long-press progress 0.0–1.0, 0 if not pressing. */
+static float getLongPressProgress();
 ```
 
-### 9.4 Footer-Zeile optimieren
+1. `NorviOledDisplay::loop()` zeichnet Fortschrittsbalken während
+   Long-Press auf S3 (siehe 8.2)
+2. Auto-Return-Countdown: letzte 5 s zeigen `→ MAIN in 5s` im Footer
 
-**Datei:** `NorviOledDisplay.cpp` — `drawFooter()`
+### PR 4 (optional): Hint-Bar-Code aufräumen
 
-- Page-Zahl rechts: aktuell "1"–"6" statt "1/6"–"6/6" (oder Punkte-Dots)
-- Vorschlag: `◉○○○○○` statt Zahl (füllt weniger Platz und ist intuitiver)
-- Oder Zahl mit Max: `1/6`, `2/6` etc. (max. 4 Zeichen)
+**Datei:** `NorviOledDisplay.cpp`
 
-### 9.5 Hint-Bar-Code aufräumen
-
-Die aktuelle `drawButtonHints()` hat 3×3 verschachtelte Cases. Besser:
+Aktuelle `drawButtonHints()` hat 3×3 verschachtelte Cases. Refaktor in
+datengetriebene Schleife:
 
 ```cpp
 struct ButtonHint {
@@ -435,20 +589,49 @@ ButtonHint hints[3];
 
 ---
 
-## 10. Offene Fragen / Diskussion
+## 11. Review-Entscheidungen (Change-Log)
 
-1. **S3 im Aktionsmenü:** Soll die Modus-Änderung sofort生效 oder erst beim Verlassen des Menüs?
-   - Vote: **Sofort** — das Menü ist nur Auswahl, kein Formular. Nach Auswahl → zurück zu MAIN.
-2. **Belegung S3-Lang auf Info-Seiten:** Aktuell nur im Sensor-Kontext sinnvoll. Soll S3-Lang auf MAIN einen Factory Reset / Reboot anbieten?
-   - Vote: **Später** — erstmal nur Sensor-Speichern.
-3. **S1 auf MAIN:** Soll S1 von MAIN aus direkt zur letzten Seite springen (wrap) oder deaktiviert sein?
-   - Vote: **Deaktiviert** — kein Hint, keine Aktion. Der Nutzer kann nur vorwärts.
-4. **Auto-Return-Timeouts:** Sollen die unterschiedlich lang sein je nach Seite?
-   - Vote: **Einheitlich 60 s** — einfacher zu verstehen. Nur Menü und Wizard bekommen eigene Timeouts (30 s / 120 s).
+| Punkt | Review-Feedback | Entscheidung | Begründung |
+|-------|----------------|-------------|-----------|
+| Long-Press Feedback | Fortschrittsbalken fordern | ✅ **Aufgenommen** (siehe 8.2) | Kritisch für Vertrauen in die Aktion |
+| Hint-Bar i18n | Labels internationalisieren? | ⏳ **Vorerst EN**, später erweiterbar | Speicher, kein dringender Bedarf |
+| Wizard Cancel | Explizite Abbruch-Option | ✅ **S1-Cancel** (siehe 9.3) | Intuitiv, einfache Implementierung |
+| Auto-Return Warnung | Countdown vor Rückkehr | ✅ **5-s-Hinweis** (siehe 9.2) | Verhindert Überraschungen |
+| Prototyp/Test | Usability-Test empfohlen | ⏳ **Nach PR 2** — vor Merge in main | Risiko niedrig, Änderungen lokal |
+| Schritt-Indikator | Fortschritt im Wizard visualisieren | ✅ **`[1/2]`** (siehe 9.4) | Minimaler Platzbedarf |
 
 ---
 
-## 11. Visual Summary
+## 12. Offene Fragen / Diskussion
+
+1. **S3 im Aktionsmenü:** Soll die Modus-Änderung sofort生效 oder erst
+   beim Verlassen des Menüs?
+   - Vote: **Sofort** — das Menü ist nur Auswahl, kein Formular. Nach
+     Auswahl → zurück zu MAIN.
+
+2. **S3-Lang auf Info-Seiten:** Aktuell nur im Sensor-Kontext sinnvoll.
+   Soll S3-Lang auf MAIN einen Factory Reset / Reboot anbieten?
+   - Vote: **Später** — erstmal nur Sensor-Speichern. Long-Press wird
+     als Konzept etabliert, aber nicht überall mit Funktion belegt.
+
+3. **S1 auf MAIN:** Soll S1 von MAIN aus direkt zur letzten Seite
+   springen (wrap) oder deaktiviert sein?
+   - Vote: **Deaktiviert** — kein Hint, keine Aktion. Der Nutzer kann
+     nur vorwärts. Der Wrap ist nicht intuitiv.
+
+4. **Auto-Return-Timeouts:** Sollen die unterschiedlich lang sein je
+   nach Seite?
+   - Vote: **Ja** — Info-Seiten 60 s, Menü 30 s, Wizard 120 s.
+     Unterschiedliche Kontexte brauchen unterschiedliche Bedenkzeit.
+
+5. **Prototyp:** Soll vor der main-Integration ein Prototyp aufgespielt
+   werden?
+   - Vote: **Ja** — PR 2 auf OTA-Kanal `dev` flashen und 1 Woche testen.
+     Gibt Rückmeldung ob Menü-Navigation sich natürlich anfühlt.
+
+---
+
+## 13. Visual Summary
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -466,20 +649,22 @@ ButtonHint hints[3];
 │  └──────┘     │ (Sensor) │      │ reboot   │        │
 │               └──────────┘      └──────────┘        │
 │                                                       │
-│   FAQ: "prev" auf S1 ≠ "next" auf S2                 │
-│   → Klare Richtungshinweise, kein "nxt" mehr         │
-│                                                       │
-│   S3 nie 'ok' auf Info-Seiten                         │
-│   → Entweder 'menu' (MAIN) oder leer                 │
-│                                                       │
-│   Aktion erfordert immer zwei Schritte:               │
-│   S3→menu → S1/S2→Auswahl → S3→Bestätigung           │
+│  Kern-Änderungen:                                     │
+│  - "prev" auf S1 ≠ "next" auf S2                     │
+│  - S3 nie 'ok' auf Info-Seiten                       │
+│  - Aktion in 2 Schritten (S3→menu→Auswahl→S3)        │
+│  - Long-Press mit Fortschrittsbalken                 │
+│  - Wizard-Cancel + Schritt-Indikator                 │
+│  - Auto-Return mit 5s-Vorwarnung                     │
 └─────────────────────────────────────────────────────┘
 ```
 
 ---
 
-> **Nächste Schritte:** Review des Konzepts, dann Implementierung in folgenden PRs:
-> 1. Hint-Labels korrigieren + Footer verbessern (niedriges Risiko)
-> 2. S3-Aktionsmenü einbauen (mittleres Risiko, neue State-Machine)
-> 3. Wizard-Cancel + Long-Press-Modell (mittleres Risiko)
+> **Nächste Schritte:**
+> 1. Finales Review des Konzepts
+> 2. **PR 1** — Hint-Labels + Footer (sofort umsetzbar)
+> 3. **PR 2** — Aktionsmenü + Wizard-Cancel (mittelfristig)
+> 4. **PR 3** — Long-Press-Feedback + Auto-Return-Warnung
+> 5. **Optional:** PR 4 — Code-Refaktor Hint-Bar
+> 6. Prototyp-Test auf OTA-Kanal `dev` vor Merge in main

--- a/docs/norvi-display-navigation-concept.de.md
+++ b/docs/norvi-display-navigation-concept.de.md
@@ -98,7 +98,7 @@ S3 ist **immer** die Aktionstaste — was sie tut, steht im Hint-Label.
 
 | Seite | S1 | S2 | S3 | S3-Lang |
 |-------|----|----|----|---------|
-| MAIN | — | next | menu | — |
+| MAIN | wrap | next | menu | — |
 | NETWORK | prev | next | — | — |
 | SYSTEM | prev | next | — | — |
 | QRCODE | prev | next | — | — |
@@ -376,7 +376,7 @@ Die Hint-Bar zeigt **nur** die aktuell relevanten Aktionen:
 
 | Seite | Sichtbare Hints | Begründung |
 |-------|----------------|-----------|
-| MAIN | S2: next, S3: menu | S1 hat keine Funktion (erste Seite) |
+| MAIN | S1: wrap, S2: next, S3: menu | S1 springt zur letzten Seite (Wrap-Around) |
 | NETWORK–QRCODE | S1: prev, S2: next | S3 hat keine Funktion auf Info-Seiten |
 | SENSOR_SETUP (aktiv) | S1: up, S2: dn, S3: select/assign | Wizard braucht alle drei |
 | Aktionsmenü | S1: ▲, S2: ▼, S3: select | Menü-Navigation + Bestätigung |
@@ -666,15 +666,10 @@ ButtonHint hints[3];
 
 3. **S1 auf MAIN:** Soll S1 von MAIN aus direkt zur letzten Seite
    springen (wrap) oder deaktiviert sein?
-   - Vote: **Deaktiviert** — kein Hint, keine Aktion. Der Nutzer kann
-     nur vorwärts. Der Wrap ist nicht intuitiv.
-   - ⚠️ **Gegenargument aus Review:** Bei der Ersteinrichtung (WiFi-Seite
-     am Ende der Kette) müsste der Nutzer viermal `next` drücken, um
-     zurück zur MAIN zu kommen. Ein Wrap via S1 wäre hier ein schneller
-     Rückwärtssprung. **Offen zur Diskussion.**
-   - Möglicher Kompromiss: S1 zeigt nur dann `wrap` als Hint, wenn der
-     Nutzer nicht auf MAIN gestartet ist (z. B. nach Auto-Return) und
-     zurückblättert.
+   - Vote: **Wrap-Around** — S1 springt zur letzten Seite
+     (WIFI_SETUP/QRCODE). Praktisch für die Ersteinrichtung, damit
+     man nicht viermal `next` drücken muss.
+   - Das S1-Hint zeigt `wrap`, das S2-Hint `next`.
 
 4. **Auto-Return-Timeouts:** Sollen die unterschiedlich lang sein je
    nach Seite?

--- a/docs/norvi-display-navigation-concept.de.md
+++ b/docs/norvi-display-navigation-concept.de.md
@@ -419,9 +419,26 @@ Footers eingeblendet:
 
 **Implementierung:**
 - Balkenlänge wächst von 0 % auf 100 % über 2000 ms (LONG_PRESS_MS)
-- Timer wird in der Display-loop() aktualisiert (forceRedraw während Press)
+- Timer wird in der Display-loop() aktualisiert während der Press aktiv ist
 - Bei Erreichen von 100 % → Aktion auslösen + reboot
 - Bei Loslassen vor 100 % → Balken verschwindet, keine Aktion
+
+**⚠️ I2C-Performance:** Ein voller Display-Redraw über I2C (SSD1306)
+dauert je nach Taktung 30–40 ms. Bei einem ohnehin engen 50-ms-Polling-
+Intervall der Tasten würde ein `forceRedraw` in jeder Loop()-Iteration
+das System ausbremsen oder den Tastendruck unzuverlässig machen.
+
+**Lösung — Partieller Redraw:** Statt `display.display()` (kompletter
+Buffer-Send) wird nur der geänderte Bereich des Fortschrittsbalkens per
+`display.drawFastHLine()` + `display.display()` aktualisiert. Die SSD1306
+erlaubt Page-Mode-Updates, aber der einfachste Weg ist: Buffer lokal
+halten, nur die 2–3 Zeilen des Balkens neu zeichnen und per
+`display.display()` flushen.
+
+**Fallback — Diskrete Schritte:** Falls Partial Redraw zu komplex ist,
+wird der Balken nur in 4–5 diskreten Stufen aktualisiert (alle ~400 ms
+eine Stufe mehr). Das reduziert die I2C-Last von 50 Hz auf ~2,5 Hz und
+ist für den Nutzer kaum wahrnehmbar langsamer.
 
 ### 8.3 Alternative: Invertiertes Label
 
@@ -468,16 +485,36 @@ Auf allen anderen Seiten hat S3-Lang keine Funktion (keine Überraschung).
 **Verhalten:**
 - Timeout wird nur **zwischen** Tastendrücken gemessen. Solange der Nutzer
   aktiv ist, passiert nichts.
-- 5 s vor Auto-Return wird auf dem Display ein kurzer Hinweis eingeblendet:
-  z. B. `→ MAIN in 5s` rechts unten im Footer (blinkend).
+- **Einheitliche Vorwarnung:** In **allen** Zuständen (Info-Seiten,
+  Aktionsmenü, Wizard) wird 5 s vor Auto-Return ein kurzer Hinweis
+  eingeblendet. Der Text ist kontextabhängig:
+  - Info-Seiten: `→ MAIN in 5s` (rechts unten im Footer, blinkend)
+  - Aktionsmenü: `→ MAIN in 5s` (gleiche Stelle)
+  - Wizard: `→ IDLE in 5s` (da Wizard zuerst auf IDLE, dann MAIN)
 
 ### 9.3 Wizard-Cancel / Rückzug
 
 Im Sensor-Wizard gibt es aktuell keinen Weg zurück.
 
 **Vorschlag 1 — S1-Cancel (bevorzugt):**
-S1 auf der ersten Wizard-Stufe, wenn `setupSelectedDev_ == 0`, zeigt
-`back` und setzt bei nochmaligem Drücken auf IDLE zurück.
+Sobald `setupSelectedDev_ == 0` (erste Option in der Liste) wechselt das
+S1-Hint-Label von `up` zu **`back`** und wird **invertiert dargestellt**
+(weisser Text auf schwarzem Grund via `dspInvertedText()`). Ein erneuter
+Druck auf S1 setzt auf IDLE zurück. Dieses Label-Switching macht den
+Ausstieg für den Nutzer offensichtlich — er sieht sofort, dass jetzt eine
+neue Aktion möglich ist.
+
+```
+┌──────────────────────┬──────┐
+│ Sensor Setup   [1/2] │      │
+│──────────────────────│ S1 ■│ back   <- invertiertes Label
+│ ▓0: 28FFAABB  SOLAR  │ S2 ▼│ dn
+│   22.5°C        ◄    │ S3 ●│ select
+│ 1: 28FECD12          │      │
+├──────────────────────┴──────┤
+│ S1=back  S2=dn  S3=select  │
+└─────────────────────────────┘
+```
 
 ```cpp
 void NorviOledDisplay::setupSelectPrevious() {
@@ -497,8 +534,9 @@ Falls S1-Kurz immer „vorherige Option" bleiben soll: S1 lang (>2 s) in
 SELECT_SENSOR bricht ab → zurück zu IDLE. Vorteil: kein unbeabsichtigter
 Cancel. Nachteil: inkonsistentes Long-Press-Modell (bisher nur S3).
 
-**Entscheidung:** Vorschlag 1 (S1-Kurz am Ende der Liste). Einfach zu
-implementieren, intuitiv („weiter zurück geht nicht → zurück zum Start").
+**Entscheidung:** Vorschlag 1 (S1-Kurz mit Label-Wechsel). Der Nutzer
+muss nicht raten — er sieht `back` und weiss, was passiert. Das
+invertierte Label macht es zusätzlich prominent.
 
 ### 9.4 Schritt-Indikator im Wizard
 
@@ -509,6 +547,13 @@ Der Wizard (SENSOR_SETUP) bekommt einen visuellen Schritt-Indikator:
 - **Alternativ:** Drei kleine Punkte `●○○` / `○●○` / `○○●` — aber bei nur
   2 Schritten unnötig komplex
 - **Umsetzung:** Minimaler Platzbedarf (ca. 25 px in der oberen Zeile)
+
+**⚠️ Platzbedarf:** Die Titelzeile `Sensor Setup [1/2]` ist mit 18 Zeichen
+(bei 6×8-Pixel-Font = 108 px) sehr knapp bemessen — die Hint-Bar beginnt
+bei Spalte 98 (Breite ~30 px). **Empfehlung:** Der Titel wird zu
+`Setup [1/2]` verkürzt (14 Zeichen ≈ 84 px), was ausreichend Abstand zur
+Hint-Bar lässt. Alternativ kann der Schritt-Indikator in die zweite Zeile
+(rechts neben dem Trennstrich) ausweichen.
 
 ### 9.5 QR-Code-Seiten ohne Hint-Bar
 
@@ -568,7 +613,11 @@ static float getLongPressProgress();
 
 1. `NorviOledDisplay::loop()` zeichnet Fortschrittsbalken während
    Long-Press auf S3 (siehe 8.2)
-2. Auto-Return-Countdown: letzte 5 s zeigen `→ MAIN in 5s` im Footer
+2. **I2C-Performance:** Fortschrittsbalken nutzt **partiellen Redraw**
+   (nur die Balken-Pixel via `display.drawFastHLine()` aktualisieren,
+   nicht den gesamten Buffer) oder **diskrete 4–5 Stufen** alle 400 ms
+   (siehe 8.2)
+3. Auto-Return-Countdown: letzte 5 s zeigen `→ MAIN in 5s` im Footer
 
 ### PR 4 (optional): Hint-Bar-Code aufräumen
 
@@ -594,11 +643,12 @@ ButtonHint hints[3];
 | Punkt | Review-Feedback | Entscheidung | Begründung |
 |-------|----------------|-------------|-----------|
 | Long-Press Feedback | Fortschrittsbalken fordern | ✅ **Aufgenommen** (siehe 8.2) | Kritisch für Vertrauen in die Aktion |
+| I2C-Performance | Balken-Update kann Loop blockieren | ✅ **Partial Redraw** oder **5 diskrete Stufen** (siehe 8.2) | 50ms Polling vs. 30-40ms I2C-Transfer |
 | Hint-Bar i18n | Labels internationalisieren? | ⏳ **Vorerst EN**, später erweiterbar | Speicher, kein dringender Bedarf |
-| Wizard Cancel | Explizite Abbruch-Option | ✅ **S1-Cancel** (siehe 9.3) | Intuitiv, einfache Implementierung |
-| Auto-Return Warnung | Countdown vor Rückkehr | ✅ **5-s-Hinweis** (siehe 9.2) | Verhindert Überraschungen |
+| Wizard Cancel | Explizite Abbruch-Option | ✅ **S1-Cancel mit Label-Wechsel** (siehe 9.3) | Intuitiv + sichtbar (`up`→`back` invertiert) |
+| Auto-Return Warnung | Countdown vor Rückkehr | ✅ **5-s-Hinweis in allen Zuständen** (siehe 9.2) | Verhindert Überraschungen auch im Wizard |
 | Prototyp/Test | Usability-Test empfohlen | ⏳ **Nach PR 2** — vor Merge in main | Risiko niedrig, Änderungen lokal |
-| Schritt-Indikator | Fortschritt im Wizard visualisieren | ✅ **`[1/2]`** (siehe 9.4) | Minimaler Platzbedarf |
+| Schritt-Indikator | Fortschritt im Wizard visualisieren | ✅ **`Setup [1/2]`** (siehe 9.4) | Kürzer, damit nicht in Hint-Bar ragend |
 
 ---
 
@@ -618,6 +668,13 @@ ButtonHint hints[3];
    springen (wrap) oder deaktiviert sein?
    - Vote: **Deaktiviert** — kein Hint, keine Aktion. Der Nutzer kann
      nur vorwärts. Der Wrap ist nicht intuitiv.
+   - ⚠️ **Gegenargument aus Review:** Bei der Ersteinrichtung (WiFi-Seite
+     am Ende der Kette) müsste der Nutzer viermal `next` drücken, um
+     zurück zur MAIN zu kommen. Ein Wrap via S1 wäre hier ein schneller
+     Rückwärtssprung. **Offen zur Diskussion.**
+   - Möglicher Kompromiss: S1 zeigt nur dann `wrap` als Hint, wenn der
+     Nutzer nicht auf MAIN gestartet ist (z. B. nach Auto-Return) und
+     zurückblättert.
 
 4. **Auto-Return-Timeouts:** Sollen die unterschiedlich lang sein je
    nach Seite?

--- a/docs/norvi-display-navigation-concept.de.md
+++ b/docs/norvi-display-navigation-concept.de.md
@@ -356,6 +356,33 @@ Optimalerweise wird Long-Press auf S3 **auf allen Seiten** konsistent als „erw
 Auf QRCODE und WIFI_SETUP wird die Hint-Bar aktuell ausgeblendet, um Platz für den QR-Code zu schaffen.
 Das ist akzeptabel, da der QR-Code die primäre Interaktion ist und der Nutzer auf diesen Seiten typischerweise nicht navigiert, sondern scannt.
 
+### 8.6 Horizontaler Text-Scroll bei Überlänge
+
+Das Display zeigt 128 Pixel Breite. Bei Text Size 1 (6×8 px/Zeichen) passen ca. **21 Zeichen** in eine Zeile.
+Folgende Texte können diese Länge überschreiten und **müssen horizontal scrollen** statt abgeschnitten zu werden:
+
+| Seite | Text | Maximale Länge | Problem |
+|-------|------|---------------|---------|
+| NETWORK | WiFi SSID | 32 Zeichen | Wird auf 9 Zeichen gekürzt — unbrauchbar |
+| WIFI_SETUP | AP-Name (SoftAP SSID) | 32 Zeichen | Wird auf 14 Zeichen gekürzt |
+| QRCODE | URL (http://192.168.xxx.xxx/) | ~23 Zeichen | Wird auf 20 Zeichen gekürzt |
+| QRCODE (WiFi) | IP-Adresse in Text Size 2 | ~14 Zeichen | Überläuft die 128px (12px/Zeichen) |
+
+**Scroll-Verhalten:**
+- Text beginnt sichtbar (linksbündig) — 2 s Pause
+- Scrollt mit **25 px/s** nach links, bis das Ende sichtbar ist
+- 1 s Pause am Ende
+- Scrollt mit **50 px/s** zurück zum Start
+- Wiederholt endlos
+- Reset bei Seitenwechsel oder Textänderung
+
+**Implementierung:**
+- `drawScrollingText(x, y, text, maxWidth)` — freie Hilfsfunktion in `NorviOledDisplay.cpp`
+- Nutzt das Hardware-Clipping des SSD1306: Zeichnen bei negativem `x` blendet den überstehenden Teil automatisch aus
+- Funktioniert nur mit Text Size 1 (für Size 2 müsste der Faktor angepasst werden)
+- Zustandsautomat (Phase 0–3) mit `millis()`-gesteuerter Animation
+- Flash-freundlich: kein `String`, keine dynamische Allokation
+
 ---
 
 ## 9. Umsetzungsplan (Code-Änderungen)
@@ -419,7 +446,33 @@ void NorviOledDisplay::setupSelectPrevious() {
 - Vorschlag: `◉○○○○○` statt Zahl (füllt weniger Platz und ist intuitiver)
 - Oder Zahl mit Max: `1/6`, `2/6` etc. (max. 4 Zeichen)
 
-### 9.5 Hint-Bar-Code aufräumen
+### 9.5 Horizontalen Text-Scroll einbauen
+
+**Dateien:** `NorviOledDisplay.cpp` — neue Hilfsfunktion + Änderung in `drawNetworkPage()`, `drawWiFiSetupPage()`, `drawQrCodePage()`
+
+```cpp
+/**
+ * @brief Draw text with horizontal scrolling if it exceeds maxWidth.
+ * Pauses 2s, scrolls left 25 px/s, pauses 1s, rewinds 50 px/s.
+ * Animation resets on page or text change.
+ */
+static void drawScrollingText(int16_t x, int16_t y,
+                               const char *text, int16_t maxWidth);
+
+/// Überladung für PROGMEM-Strings (__FlashStringHelper)
+static void drawScrollingText(int16_t x, int16_t y,
+                               const __FlashStringHelper *text,
+                               int16_t maxWidth);
+```
+
+**Betroffene Aufrufe:**
+| Seite | Alt | Neu |
+|-------|-----|-----|
+| NETWORK, SSID | `ssid.substring(0,9)` | `drawScrollingText(36, 13, WiFi.SSID().c_str(), 92)` |
+| WIFI_SETUP, AP-Name | `apName.substring(0,14)` | `drawScrollingText(24, 12, WiFi.softAPSSID().c_str(), 104)` |
+| QRCODE, URL | `url.substring(0,20)` | `drawScrollingText(0, 0, url.c_str(), 128)` |
+
+### 9.6 Hint-Bar-Code aufräumen
 
 Die aktuelle `drawButtonHints()` hat 3×3 verschachtelte Cases. Besser:
 

--- a/docs/norvi-display-navigation-concept.de.md
+++ b/docs/norvi-display-navigation-concept.de.md
@@ -1,0 +1,485 @@
+# Bedien- und Navigationskonzept — NORVI IIOT-AE01-R OLED + 3 Tasten
+
+> **Status:** Konzept / RFC  
+> **Ziel:** Verbesserung der UX des 128×64 OLED-Displays mit den drei Fronttasten (S1/S2/S3)  
+> **Behandelt:** Button-Mapping, Bildschirm-Hierarchie, Hints, Wizard-Navigation, Sonderfälle
+
+---
+
+## 1. Physikalische Gegebenheiten
+
+- **Display:** 0,96″ SSD1306 OLED, 128×64 Pixel, I2C (Adresse 0x3C)
+- **Tasten:** 3 Tact-Switches rechts neben dem Display (vertikale Anordnung)
+  - **S1 (oben)** — ▲
+  - **S2 (Mitte)** — ▼
+  - **S3 (unten)** — ●
+- **Tasten-Interface:** Resistor-Ladder an GPIO32 (ADC), kein Interrupt — Polling alle 50 ms
+- **Long-Press:** Erkennung nach >2 s, kann Short-Press konsumieren (Callback-Rückgabe `true`)
+
+---
+
+## 2. Ist-Analyse: UX-Probleme der aktuellen Implementierung
+
+### 2.1 S3 ist überladen und gefährlich
+
+| Kontext | S3-Kurz (aktuell) | Problem |
+|---------|-------------------|---------|
+| MAIN    | Betriebsmodus cyclen (auto→manu→boost→timer) | Ein Tastendruck ändert unumkehrbar den Betriebsmodus. Ein versehentlicher Druck während des Vorbeiscrollens schaltet von `auto` auf `manu` — die Pumpe läuft dann dauerhaft. |
+| Andere Infoseiten | Betriebsmodus cyclen | Der Nutzer erwartet auf PAGE 3 (QRCODE) keine Modus-Änderung. |
+| SENSOR_SETUP | Wizard-Advance | Einziger Kontext, in dem S3 sinnvoll ist. |
+
+**➜ S3 darf auf Infoseiten keine Seiteneffekte haben, die den Anlagenbetrieb verändern.**
+
+### 2.2 Hint-Labels „nxt" für S1 und S2
+
+Beide Tasten zeigen auf normalen Seiten das Label `nxt`. Damit ist nicht ersichtlich, dass S1 **zurück** und S2 **vor** blättert. Der Nutzer muss durch Trial & Error herausfinden, welche Taste wohin navigiert.
+
+### 2.3 Fehlende visuelle Hierarchie
+
+- Keine Unterscheidung zwischen „Info-Seiten" und „Interaktions-Seiten"
+- Kein Hinweis, dass man sich auf Seite X von Y befindet (nur eine nackte Zahl rechts unten)
+- Kein „Exit"- oder „Back"-Gefühl — einmal im Sensor-Wizard steckt man fest, bis man entweder fertig ist oder 60 s gewartet hat
+
+### 2.4 Long-Press ist unsichtbar
+
+- S3 lang speichert Sensor-Mapping und rebootet — aber der Nutzer sieht das nirgends, solange nicht beide Sensoren zugewiesen sind.
+- Es gibt kein konsistentes Long-Press-Modell, das der Nutzer lernen und erwarten kann.
+
+### 2.5 Auto-Return ohne Vorwarnung
+
+- Nach 60 s springt das Display unhinterfragt zurück zu MAIN — das kann mitten im Lesen einer IP-Adresse passieren.
+
+---
+
+## 3. Design-Prinzipien
+
+1. **Konsistenz:** Jede Taste hat eine gleichbleibende Grundbedeutung (S1=▲=rauf/zurück, S2=▼=runter/vor, S3=●=Aktion/bestätigen).
+2. **Sicherheit:** Keine Taste ändert den Anlagenzustand ohne explizite Bestätigung oder klares Label.
+3. **Sichtbarkeit:** Jede Taste hat ein kontextspezifisches, eindeutiges Hint-Label.
+4. **Minimale Überraschung:** Keine Side-Effects beim Scrollen. Aktionen sind explizit.
+5. **Fat-Finger-freundlich:** Wichtige Aktionen erfordern zwei Schritte oder Long-Press.
+
+---
+
+## 4. Vorgeschlagenes Button-Mapping
+
+### 4.1 Grundzuordnung (gilt als Default)
+
+| Taste | Label | Kurz (Normal) | Kurz (Wizard) | Lang (>2 s) |
+|-------|-------|---------------|---------------|-------------|
+| **S1** | ▲ | Vorherige Seite | Vorherige Option | — (nicht belegt) |
+| **S2** | ▼ | Nächste Seite | Nächste Option | — (nicht belegt) |
+| **S3** | ● | Aktion / Enter (siehe Seite) | Bestätigen / Weiter | Kontext-Aktion (speichern, reboot) |
+
+S1 und S2 sind **immer** Navigation — egal ob zwischen Seiten oder innerhalb eines Wizards.  
+S3 ist **immer** die Aktionstaste — was sie tut, steht im Hint-Label.
+
+### 4.2 Hint-Labels pro Seite
+
+| Seite | S1-Hint | S2-Hint | S3-Hint | S3-Lang |
+|-------|---------|---------|---------|---------|
+| MAIN | — | next | menu | — |
+| NETWORK | prev | next | — | — |
+| SYSTEM | prev | next | — | — |
+| QRCODE | prev | next | — | — |
+| WIFI_SETUP | prev | next | — | — |
+| SENSOR_SETUP (IDLE) | — | — | setup | save+reboot |
+| SENSOR_SETUP (SELECT) | up | dn | select | — |
+| SENSOR_SETUP (ROLE) | up | dn | assign | — |
+
+**Änderungen:**
+- S1 zeigt `prev` statt `nxt` — eindeutig anders als S2 (`next`)
+- S3 zeigt **nie** `ok` auf Infoseiten, sondern ist entweder leer (keine Aktion) oder zeigt klar, was passiert (`menu`, `setup`, `select`, `assign`)
+- MAIN-Seite: S3 öffnet ein Aktionsmenü statt direkt den Modus zu wechseln
+
+---
+
+## 5. Bildschirm-Hierarchie
+
+```
+┌─────────────────────────────────────┐
+│         INFO-MODUS                   │
+│  (Seiten: MAIN / NETWORK / SYSTEM / │
+│   QRCODE / WIFI_SETUP)              │
+│                                     │
+│  S1/S2 = prev/next                  │
+│  S3    = kontextspezifisch          │
+│  Auto-Return nach 60 s → MAIN      │
+└──────────────────┬──────────────────┘
+                   │ S3 in MAIN
+                   ▼
+┌─────────────────────────────────────┐
+│         AKTIONSMENÜ (MAIN)          │
+│                                     │
+│  > Mode: auto                       │
+│    Pump: on/off                     │
+│    → Back                           │
+│                                     │
+│  S1/S2 = Menü-Zeile wechseln       │
+│  S3    = Auswahl aktivieren         │
+└─────────────────────────────────────┘
+
+┌─────────────────────────────────────┐
+│      SENSOR-SETUP-WIZARD            │
+│  (erreichbar via S3 auf Seite       │
+│   SENSOR_SETUP)                     │
+│                                     │
+│  Step 1: SELECT_SENSOR              │
+│  S1/S2 = up/dn (Sensor wählen)      │
+│  S3    = select (bestätigen)        │
+│                                     │
+│  Step 2: SELECT_ROLE                │
+│  S1/S2 = up/dn (Solar/Pool)         │
+│  S3    = assign (zuweisen)          │
+│                                     │
+│  Nach assign → zurück zu IDLE       │
+│  S3 lang = save+reboot (wenn beide  │
+│            Sensoren zugewiesen)     │
+└─────────────────────────────────────┘
+```
+
+---
+
+## 6. Detaillierte Seitenbeschreibungen
+
+### 6.1 MAIN — Übersichtsseite
+
+```
+┌──────────────────────┬──────┐
+│ ● 22.5°C             │      │
+│ Pool       auto      │ S2 ▼│ next
+│ ○ 19.1°C             │ S3 ●│ menu
+│ Solar                │      │
+├──────────────────────┴──────┤
+│ AUTO  12:30  v2.1.0     1  │
+└─────────────────────────────┘
+```
+
+- S2 = `next` → nächste Info-Seite (NETWORK)
+- S3 = `menu` → öffnet Aktionsmenü (siehe 6.6)
+- S1 = kein Hint, da MAIN die erste Seite ist (kein „prev" nötig)
+
+### 6.2 NETWORK — Netzwerkstatus
+
+```
+┌──────────────────────┬──────┐
+│ Network Status       │      │
+│──────────────────────│ S1 ▲│ prev
+│ WiFi: MyHomeWLAN     │ S2 ▼│ next
+│ IP: 192.168.1.42     │ S3  │
+│ MQTT: CONNECTED      │      │
+├──────────────────────┴──────┤
+│ AUTO  12:30  v2.1.0     2  │
+└─────────────────────────────┘
+```
+
+- S1/S2 = Seiten blättern (wrap-around über MAIN–QRCODE)
+- S3 = kein Hint — kein Side-Effect
+
+### 6.3 SYSTEM — Systeminformationen
+
+```
+┌──────────────────────┬──────┐
+│ System Info          │      │
+│──────────────────────│ S1 ▲│ prev
+│ Up: 12d 5h 32m       │ S2 ▼│ next
+│ Heap: 123456 B       │ S3  │
+│ FW: v2.1.0           │      │
+│ Min: 98000 B         │      │
+├──────────────────────┴──────┤
+│ AUTO  12:30  v2.1.0     3  │
+└─────────────────────────────┘
+```
+
+### 6.4 QRCODE — Web-Interface QR
+
+```
+┌──────────────────────┬──────┐
+│ http://192.168.1.42  │      │
+│ ┌──────────────┐     │ S1 ▲│ prev
+│ │  ██  ██  ██  │     │ S2 ▼│ next
+│ │  ██  ██  ██  │     │ S3  │
+│ │  ██  ██  ██  │     │      │
+│ └──────────────┘     │      │
+├──────────────────────┴──────┤
+│ AUTO  12:30  v2.1.0     4  │
+└─────────────────────────────┘
+```
+
+### 6.5 WIFI_SETUP — Ersteinrichtung
+
+Identisch zu QRCODE im Layout, aber mit zusätzlichem Text zur WiFi-Einrichtung.
+
+### 6.6 Aktionsmenü (auf MAIN via S3)
+
+```
+┌──────────────────────┬──────┐
+│ > Mode: auto ◄       │      │
+│   Pump: on/off       │ S1 ▲│
+│   → Exit menu        │ S2 ▼│
+│                      │ S3 ●│ select
+│                      │      │
+├──────────────────────┴──────┤
+│ AUTO  12:30  v2.1.0     1  │
+└─────────────────────────────┘
+```
+
+| Menü-Eintrag | S3-Aktion |
+|-------------|-----------|
+| **Mode: auto** | Modus cyclen (auto→manu→boost→timer→auto) + sofort zurück zu MAIN |
+| **Pump: on/off** | Pumpe manuell ein/aus + zurück zu MAIN |
+| **→ Exit menu** | Zurück zu MAIN ohne Änderung |
+
+S1/S2 navigieren zwischen den Menüzeilen. S3 bestätigt die Auswahl.
+
+**Warum ein Menü statt direkter Modus-Cycle?**
+- Der Nutzer muss aktiv ins Menü gehen → kein versehentlicher Modus-Wechsel beim Blättern
+- Das Label `menu` auf S3 ist eindeutig und erwartbar
+- Langfristig können hier weitere Aktionen ergänzt werden (Pumpe togglen, Relais-Status, Neustart)
+
+### 6.7 SENSOR_SETUP — Sensor-Zuordnungswizard
+
+**Step 1 — SELECT_SENSOR:**
+
+```
+┌──────────────────────┬──────┐
+│ Sensor Setup         │      │
+│──────────────────────│ S1 ▲│ up
+│ ▓0: 28FFAABB  <-SOLAR│ S2 ▼│ dn
+│   22.5°C        ◄    │ S3 ●│ select
+│ 1: 28FECD12          │      │
+│   19.1°C             │      │
+├──────────────────────┴──────┤
+│ S1/S2=pick  S3=select       │
+└─────────────────────────────┘
+```
+
+**Step 2 — SELECT_ROLE:**
+
+```
+┌──────────────────────┬──────┐
+│ Sensor Setup         │      │
+│──────────────────────│ S1 ▲│ up
+│ 0: 28FFAABB  SOLAR   │ S2 ▼│ dn
+│ ┌──────────────────┐ │ S3 ●│ assign
+│ │ Assign as:       │ │      │
+│ │ ▓Solar           │ │      │
+│ │   Pool           │ │      │
+│ └──────────────────┘ │      │
+├──────────────────────┴──────┤
+│ S1/S2=role  S3=assign       │
+└─────────────────────────────┘
+```
+
+**IDLE-Zustand (beide zugewiesen):**
+
+```
+┌──────────────────────┬──────┐
+│ Sensor Setup         │      │
+│──────────────────────│      │
+│ 0: 28FFAABB  SOLAR   │ S3 ●│ setup
+│ 1: 28FECD12  POOL    │      │
+│                      │ S3  │
+│                      │  lang│ save+reboot
+├──────────────────────┴──────┤
+│ Both set. Hold S3=Save      │
+└─────────────────────────────┘
+```
+
+---
+
+## 7. Hint-Bar-Design (rechte Spalte)
+
+Die Hint-Bar nutzt die rechten ~30 Pixel (Spalten 98–127). Sie wird auf allen Info-Seiten gezeichnet.
+
+```
+Spalte:  98     108    118    128
+         ┌──────┬──────┬──────┐
+         │      │      │      │
+    S1   │ prev │  ▲   │      │   <- Text, darunter Dreieck-Symbol
+         │      │      │      │
+   Trenner│      │      │      │   <- vertikale Linie
+         │      │      │      │
+    S2   │ next │  ▼   │      │
+         │      │      │      │
+   Trenner│      │      │      │
+         │      │      │      │
+    S3   │ menu │  ●   │      │
+         │      │      │      │
+         └──────┴──────┴──────┘
+```
+
+**Gestaltungsregeln:**
+- S1 ist oben, S2 mitte, S3 unten — exakt wie die physikalische Anordnung
+- Das Label steht **links** vom Symbol, damit es gelesen wird bevor das Auge zum Symbol wandert
+- Wenn eine Taste keine Aktion hat, wird sie ausgeblendet (kein Text, kein Symbol)
+- Symbole: ▲ (S1), ▼ (S2), ● (S3) — auch in der Lücke ohne Text erkennbar
+- Die Farbgebung bleibt monochrom (SSD1306_WHITE)
+
+---
+
+## 8. Sonderfälle & Edge Cases
+
+### 8.1 Erster Boot (kein WiFi / keine Sensor-Mapping)
+
+- Display startet automatisch auf **WIFI_SETUP** oder **SENSOR_SETUP** (bereits implementiert)
+- Button-Verhalten ist identisch zu den normalen Seiten — S1/S2 blättern, S3 hat keine Aktion außer auf SENSOR_SETUP
+- Der Nutzer muss zwingend ins Web-Interface — das Display macht das klar („Scan QR or enter URL")
+
+### 8.2 Auto-Return-Timeouts
+
+| Zustand | Timeout | Ziel |
+|---------|---------|------|
+| Info-Seite (nicht MAIN) | 60 s | MAIN |
+| Aktionsmenü | 30 s | MAIN |
+| Sensor-Wizard (SELECT) | 120 s | IDLE+MAIN |
+| Sensor-Wizard (ROLE) | 120 s | IDLE+MAIN |
+
+- **Neu:** 5 s vor Auto-Return wird der Bildschirm nicht sofort umgeschaltet — stattdessen läuft das Menü einfach aus. Der Timeout wird nur **zwischen** Tastendrücken gemessen. Solange der Nutzer aktiv ist, passiert nichts.
+
+### 8.3 Wizard-Cancel / Rückzug
+
+Im Sensor-Wizard gibt es aktuell keinen Weg zurück, außer abzubrechen (Timeout).  
+**Vorschlag:** S1 auf der ersten Wizard-Stufe (SELECT_SENSOR) zeigt `back`, wenn `setupSelectedDev_ == 0` und der Nutzer nochmal S1 drückt → zurück zu IDLE.  
+(Das erfordert minimale Logik-Änderung in `setupSelectPrevious()`.)
+
+### 8.4 Long-Press-Modell
+
+Long-Press wird nur für **kritische, bestätigungspflichtige Aktionen** genutzt:
+- Sensor-Mapping speichern + Reboot
+- Zukünftig: Factory Reset, Safe Mode
+
+Optimalerweise wird Long-Press auf S3 **auf allen Seiten** konsistent als „erweiterte Aktion" etabliert.
+
+### 8.5 QR-Code-Seiten mit vollem Bildschirm
+
+Auf QRCODE und WIFI_SETUP wird die Hint-Bar aktuell ausgeblendet, um Platz für den QR-Code zu schaffen.
+Das ist akzeptabel, da der QR-Code die primäre Interaktion ist und der Nutzer auf diesen Seiten typischerweise nicht navigiert, sondern scannt.
+
+---
+
+## 9. Umsetzungsplan (Code-Änderungen)
+
+### 9.1 Hint-Labels korrigieren
+
+**Dateien:** `NorviOledDisplay.cpp` — Funktion `drawButtonHints()`
+
+| Change | Aktuell | Neu |
+|--------|---------|-----|
+| S1-Label auf Info-Seiten | `nxt` | `prev` |
+| S2-Label auf Info-Seiten | `nxt` | `next` |
+| S3 auf MAIN | `ok` | `menu` |
+| S3 auf NETWORK/SYSTEM/QRCODE/WIFI_SETUP | `ok` | leer (ausblenden) |
+
+### 9.2 S3-Modus-Cycle entfernen, Aktionsmenü einbauen
+
+**Datei:** `PoolController.cpp` — Callback S3
+
+Statt direktem Mode-Cycle:
+1. S3 auf MAIN → setzt internen `menuActive_`-Flag
+2. Display zeigt Menü-Overlay (3 Zeilen: Mode, Pump, Exit)
+3. S1/S2 navigieren im Menü
+4. S3 bestätigt Auswahl
+5. S3 (oder Exit) → zurück zu MAIN
+
+Separate kleine State-Machine in `NorviOledDisplay`:
+```cpp
+enum class MenuItem : uint8_t {
+  MODE,
+  PUMP,
+  EXIT
+};
+static MenuItem menuSelection_;
+static bool menuActive_;
+```
+
+### 9.3 Wizard-Cancel
+
+**Datei:** `NorviOledDisplay.cpp` — `setupSelectPrevious()`
+
+Wenn `setupSelectedDev_ == 0` und nochmal `previous()` → zurücksetzen auf IDLE.
+
+```cpp
+void NorviOledDisplay::setupSelectPrevious() {
+  if (setupSelectedDev_ == 0 && setupStep_ == SetupStep::SELECT_SENSOR) {
+    // Back to IDLE
+    setupStep_ = SetupStep::IDLE;
+    forceRedraw_ = true;
+    return;
+  }
+  // ... existing logic ...
+}
+```
+
+### 9.4 Footer-Zeile optimieren
+
+**Datei:** `NorviOledDisplay.cpp` — `drawFooter()`
+
+- Page-Zahl rechts: aktuell "1"–"6" statt "1/6"–"6/6" (oder Punkte-Dots)
+- Vorschlag: `◉○○○○○` statt Zahl (füllt weniger Platz und ist intuitiver)
+- Oder Zahl mit Max: `1/6`, `2/6` etc. (max. 4 Zeichen)
+
+### 9.5 Hint-Bar-Code aufräumen
+
+Die aktuelle `drawButtonHints()` hat 3×3 verschachtelte Cases. Besser:
+
+```cpp
+struct ButtonHint {
+  const char *label;
+  bool hasIcon;
+};
+ButtonHint hints[3];
+// ... fill based on page + setup step ...
+// ... render loop ...
+```
+
+---
+
+## 10. Offene Fragen / Diskussion
+
+1. **S3 im Aktionsmenü:** Soll die Modus-Änderung sofort生效 oder erst beim Verlassen des Menüs?
+   - Vote: **Sofort** — das Menü ist nur Auswahl, kein Formular. Nach Auswahl → zurück zu MAIN.
+2. **Belegung S3-Lang auf Info-Seiten:** Aktuell nur im Sensor-Kontext sinnvoll. Soll S3-Lang auf MAIN einen Factory Reset / Reboot anbieten?
+   - Vote: **Später** — erstmal nur Sensor-Speichern.
+3. **S1 auf MAIN:** Soll S1 von MAIN aus direkt zur letzten Seite springen (wrap) oder deaktiviert sein?
+   - Vote: **Deaktiviert** — kein Hint, keine Aktion. Der Nutzer kann nur vorwärts.
+4. **Auto-Return-Timeouts:** Sollen die unterschiedlich lang sein je nach Seite?
+   - Vote: **Einheitlich 60 s** — einfacher zu verstehen. Nur Menü und Wizard bekommen eigene Timeouts (30 s / 120 s).
+
+---
+
+## 11. Visual Summary
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  NAVIGATIONSKONZEPT                   │
+│                                                       │
+│   Tasten       Infoseiten         Wizard / Menü       │
+│  ┌──────┐     ┌──────────┐      ┌──────────┐        │
+│  │ S1 ▲ │ ──→ │ prev     │      │ up/back  │        │
+│  │──────│     │ Seite◄   │      │ Option◄  │        │
+│  │ S2 ▼ │ ──→ │ next     │      │ down     │        │
+│  │──────│     │ Seite►   │      │ Option►  │        │
+│  │ S3 ● │ ──→ │ menu     │      │ select   │        │
+│  │      │     │ (MAIN)   │      │ assign   │        │
+│  │  lang│ ──→ │ save     │      │ save+    │        │
+│  └──────┘     │ (Sensor) │      │ reboot   │        │
+│               └──────────┘      └──────────┘        │
+│                                                       │
+│   FAQ: "prev" auf S1 ≠ "next" auf S2                 │
+│   → Klare Richtungshinweise, kein "nxt" mehr         │
+│                                                       │
+│   S3 nie 'ok' auf Info-Seiten                         │
+│   → Entweder 'menu' (MAIN) oder leer                 │
+│                                                       │
+│   Aktion erfordert immer zwei Schritte:               │
+│   S3→menu → S1/S2→Auswahl → S3→Bestätigung           │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+> **Nächste Schritte:** Review des Konzepts, dann Implementierung in folgenden PRs:
+> 1. Hint-Labels korrigieren + Footer verbessern (niedriges Risiko)
+> 2. S3-Aktionsmenü einbauen (mittleres Risiko, neue State-Machine)
+> 3. Wizard-Cancel + Long-Press-Modell (mittleres Risiko)

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -74,6 +74,13 @@ void NorviButtonHandler::loop() {
   lastRaw_ = analogRead(PIN_BUTTON_ADC);
   Button detected = detectButton(lastRaw_);
 
+  // Add debug logging for ADC changes
+  static uint16_t lastDebugAdc_ = 0xFFFF;
+  if (abs(static_cast<int>(lastRaw_) - static_cast<int>(lastDebugAdc_)) > 50) {
+    Serial.printf("ADC: %u → %d\n", lastDebugAdc_, static_cast<int>(detected));
+    lastDebugAdc_ = lastRaw_;
+  }
+
   // ── Press start tracking ─────────────────────────────────────────────
   if (detected != currentButton_) {
     currentButton_ = detected;

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -140,6 +140,21 @@ void NorviButtonHandler::loop() {
 
 // ═══════════════════════════════════════════════════════════════════════════
 
+// ═══════════════════════════════════════════════════════════════════════════
+
+float NorviButtonHandler::getLongPressProgress() {
+  if (currentButton_ == Button::NONE || pressStartMs_ == 0) {
+    return 0.0f;
+  }
+  uint32_t elapsed = millis() - pressStartMs_;
+  if (elapsed >= LONG_PRESS_MS) {
+    return 1.0f;
+  }
+  return static_cast<float>(elapsed) / static_cast<float>(LONG_PRESS_MS);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+
 NorviButtonHandler::Button NorviButtonHandler::detectButton(uint16_t raw) {
   if (raw >= THRESH_NO_PRESS) {
     return Button::NONE;

--- a/src/NorviButtonHandler.hpp
+++ b/src/NorviButtonHandler.hpp
@@ -159,12 +159,12 @@ private:
   // Adjust if needed based on serial debug output.
 
   static constexpr uint16_t THRESH_BTN1_MIN{200};
-  static constexpr uint16_t THRESH_BTN1_MAX{1200};
-  static constexpr uint16_t THRESH_BTN2_MIN{1400};
-  static constexpr uint16_t THRESH_BTN2_MAX{2500};
-  static constexpr uint16_t THRESH_BTN3_MIN{2700};
-  static constexpr uint16_t THRESH_BTN3_MAX{3700};
-  static constexpr uint16_t THRESH_NO_PRESS{3800};
+  static constexpr uint16_t THRESH_BTN1_MAX{700};
+  static constexpr uint16_t THRESH_BTN2_MIN{800};
+  static constexpr uint16_t THRESH_BTN2_MAX{1300};
+  static constexpr uint16_t THRESH_BTN3_MIN{1400};
+  static constexpr uint16_t THRESH_BTN3_MAX{1900};
+  static constexpr uint16_t THRESH_NO_PRESS{2000};
 };
 
 }  // namespace PoolController

--- a/src/NorviButtonHandler.hpp
+++ b/src/NorviButtonHandler.hpp
@@ -101,6 +101,14 @@ public:
   /** @brief Get the last raw ADC reading (for debugging). */
   static uint16_t getLastRawValue() { return lastRaw_; }
 
+  /**
+   * @brief Long-press progress 0.0–1.0 during a held press.
+   * Returns 0.0f if no button is pressed or long-press already fired.
+   * Returns 1.0f once LONG_PRESS_MS has elapsed.
+   * Used by NorviOledDisplay to draw a progress bar.
+   */
+  static float getLongPressProgress();
+
 private:
   /**
    * @brief Map an ADC reading to a Button ID.

--- a/src/NorviButtonHandler.hpp
+++ b/src/NorviButtonHandler.hpp
@@ -159,12 +159,12 @@ private:
   // Adjust if needed based on serial debug output.
 
   static constexpr uint16_t THRESH_BTN1_MIN{200};
-  static constexpr uint16_t THRESH_BTN1_MAX{700};
-  static constexpr uint16_t THRESH_BTN2_MIN{800};
-  static constexpr uint16_t THRESH_BTN2_MAX{1300};
-  static constexpr uint16_t THRESH_BTN3_MIN{1400};
-  static constexpr uint16_t THRESH_BTN3_MAX{1900};
-  static constexpr uint16_t THRESH_NO_PRESS{2000};
+  static constexpr uint16_t THRESH_BTN1_MAX{1200};
+  static constexpr uint16_t THRESH_BTN2_MIN{1400};
+  static constexpr uint16_t THRESH_BTN2_MAX{2500};
+  static constexpr uint16_t THRESH_BTN3_MIN{2700};
+  static constexpr uint16_t THRESH_BTN3_MAX{3700};
+  static constexpr uint16_t THRESH_NO_PRESS{3800};
 };
 
 }  // namespace PoolController

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -24,6 +24,7 @@
 #include <qrcode.h>
 
 #include "Config.hpp"
+#include "NorviButtonHandler.hpp"
 #include "Utils.hpp"
 #include "DallasTemperatureNode.hpp"
 #include "RelayModuleNode.hpp"
@@ -47,6 +48,7 @@ extern OperationModeNode operationModeNode;
 // These are called from drawPage() which appears before their definition.
 static void drawDegC(uint8_t textsize);
 static void drawButtonHints();
+static void drawProgressBar();
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Static members
@@ -78,6 +80,10 @@ bool NorviOledDisplay::menuActive_ = false;
 // ── SSD1306 display instance (128×64, I2C, address 0x3C) ─────────────────
 
 static Adafruit_SSD1306 display(128, 64, &Wire, -1);
+
+/// Auto-return warning countdown (ms until return), 0 = no warning active.
+/// Set by loop(), consumed by drawFooter().
+static uint32_t autoReturnWarningMs = 0;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Coord helpers — apply burn-in offset to all drawing
@@ -222,8 +228,26 @@ void NorviOledDisplay::loop() {
     forceRedraw_ = true;
   }
 
-  // ── Throttle redraw rate ────────────────────────────────────────────
-  if (!forceRedraw_ && (now - lastUpdateMs_ < UPDATE_INTERVAL_MS)) {
+  // ── Long-press progress: accelerate redraw during hold ──────────────
+  float longPressProgress = NorviButtonHandler::getLongPressProgress();
+  bool isLongPressing = (longPressProgress > 0.0f);
+
+  // ── Auto-return warning (5s before) ─────────────────────────────────
+  // Sets file-scope autoReturnWarningMs consumed by drawFooter()
+  if (!menuActive_ && !isSetupActive() && currentPage_ != Page::MAIN) {
+    uint32_t idleMs = now - lastButtonPressMs_;
+    if (idleMs >= AUTO_RETURN_MS - 5000 && idleMs < AUTO_RETURN_MS) {
+      autoReturnWarningMs = AUTO_RETURN_MS - idleMs;  // ms until return
+      forceRedraw_ = true;
+    } else {
+      autoReturnWarningMs = 0;
+    }
+  } else {
+    autoReturnWarningMs = 0;
+  }
+
+  // ── Throttle redraw rate (skip during long-press for smooth bar) ────
+  if (!forceRedraw_ && !isLongPressing && (now - lastUpdateMs_ < UPDATE_INTERVAL_MS)) {
     return;
   }
 
@@ -234,6 +258,7 @@ void NorviOledDisplay::loop() {
   forceRedraw_ = false;
 
   drawPage();
+  drawProgressBar();
   display.display();
 }
 
@@ -519,6 +544,38 @@ void NorviOledDisplay::drawMenuPage() {
   } else {
     dspCursor(4, Y0 + 2 * LH);
     display.print(exitItem);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Long-press progress bar overlay
+// ═══════════════════════════════════════════════════════════════════════════
+
+static void drawProgressBar() {
+  float progress = NorviButtonHandler::getLongPressProgress();
+  if (progress <= 0.0f) {
+    return;
+  }
+
+  // Only show on SENSOR_SETUP page in IDLE state with both sensors done
+  if (NorviOledDisplay::getCurrentPage() != NorviOledDisplay::Page::SENSOR_SETUP
+      || NorviOledDisplay::isSetupActive()) {
+    return;
+  }
+
+  // Bar dimensions (above footer line at y=55)
+  static constexpr uint8_t BAR_X = 4;
+  static constexpr uint8_t BAR_Y = 49;
+  static constexpr uint8_t BAR_W = 120;
+  static constexpr uint8_t BAR_H = 4;
+
+  // Border
+  dspRoundRect(BAR_X, BAR_Y, BAR_W, BAR_H, 1, SSD1306_WHITE);
+
+  // Fill
+  uint8_t fillW = static_cast<uint8_t>((BAR_W - 2) * progress);
+  if (fillW > 0) {
+    dspFillRect(BAR_X + 1, BAR_Y + 1, fillW, BAR_H - 2, SSD1306_WHITE);
   }
 }
 
@@ -1020,14 +1077,29 @@ void NorviOledDisplay::drawFooter() {
   dspCursor(68, 56);
   display.print(F("v" FW_VERSION));
 
-  // ── Page number (X/Y format) ─────────────────────────────────────────
-  dspCursor(110, 56);
+  // ── Auto-return warning (5s window) ──────────────────────────────────
+  // autoReturnWarningMs is set by loop() when idle approaches timeout
   {
-    uint8_t pageNum = static_cast<uint8_t>(currentPage_) + 1;
-    uint8_t maxPage = static_cast<uint8_t>(Page::SENSOR_SETUP);
-    char buf[8];
-    snprintf(buf, sizeof(buf), "%d/%d", pageNum, maxPage);
-    display.print(buf);
+    if (autoReturnWarningMs > 0) {
+      uint8_t secs = (autoReturnWarningMs + 999) / 1000;
+      // Overwrite version and page area with blink warning
+      dspCursor(68, 56);
+      display.print(F("→ MAIN "));
+      display.print(secs);
+      display.print('s');
+    } else {
+      // ── Firmware version ────────────────────────────────────────────
+      dspCursor(68, 56);
+      display.print(F("v" FW_VERSION));
+
+      // ── Page number (X/Y format) ────────────────────────────────────
+      dspCursor(110, 56);
+      uint8_t pageNum = static_cast<uint8_t>(currentPage_) + 1;
+      uint8_t maxPage = static_cast<uint8_t>(Page::SENSOR_SETUP);
+      char buf[8];
+      snprintf(buf, sizeof(buf), "%d/%d", pageNum, maxPage);
+      display.print(buf);
+    }
   }
 }
 

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -172,7 +172,7 @@ static void dspInvertedText(int16_t x, int16_t y, const __FlashStringHelper *tex
 // rewinds at 50 px/s. Animation resets when page or text content changes.
 
 static uint32_t scrollAnimStartMs_ = 0;
-static int8_t scrollPhase_ = 0;      // 0=pause 1=scroll-L 2=pause 3=rewind
+static int8_t scrollPhase_ = 0;  // 0=pause 1=scroll-L 2=pause 3=rewind
 static int16_t scrollOffset_ = 0;
 
 /**
@@ -183,7 +183,8 @@ static int16_t scrollOffset_ = 0;
  * manual clipping.
  */
 static void drawScrollingText(int16_t x, int16_t y, const char *text, int16_t maxWidth) {
-  if (!text || text[0] == '\0') return;
+  if (!text || text[0] == '\0')
+    return;
 
   int16_t x1, y1;
   uint16_t textW, h;
@@ -221,7 +222,10 @@ static void drawScrollingText(int16_t x, int16_t y, const char *text, int16_t ma
   switch (scrollPhase_) {
   case 0:  // Pause at start — full text visible entering from right
     scrollOffset_ = 0;
-    if (elapsed >= 2000) { scrollPhase_ = 1; scrollAnimStartMs_ = now; }
+    if (elapsed >= 2000) {
+      scrollPhase_ = 1;
+      scrollAnimStartMs_ = now;
+    }
     break;
 
   case 1:  // Scroll left at 25 px/s
@@ -234,7 +238,10 @@ static void drawScrollingText(int16_t x, int16_t y, const char *text, int16_t ma
     break;
 
   case 2:  // Pause at end — last characters visible
-    if (elapsed >= 1000) { scrollPhase_ = 3; scrollAnimStartMs_ = now; }
+    if (elapsed >= 1000) {
+      scrollPhase_ = 3;
+      scrollAnimStartMs_ = now;
+    }
     break;
 
   case 3:  // Rewind right at 50 px/s
@@ -316,8 +323,7 @@ void NorviOledDisplay::loop() {
     // Menu: 30 s idle → close menu
     menuActive_ = false;
     forceRedraw_ = true;
-  } else if (!isSetupActive() && currentPage_ != Page::MAIN
-             && (now - lastButtonPressMs_ >= AUTO_RETURN_MS)) {
+  } else if (!isSetupActive() && currentPage_ != Page::MAIN && (now - lastButtonPressMs_ >= AUTO_RETURN_MS)) {
     // Info pages (non-MAIN): 60 s idle → MAIN
     currentPage_ = Page::MAIN;
     forceRedraw_ = true;
@@ -530,7 +536,7 @@ static void drawButtonHints() {
 
   // Draw button symbols (always present)
   dspFillTriangle(121, 14, 125, 20, 117, 20, SSD1306_WHITE);  // S1 ▲
-  dspFillTriangle(117, 27, 125, 27, 121, 33, SSD1306_WHITE);   // S2 ▼
+  dspFillTriangle(117, 27, 125, 27, 121, 33, SSD1306_WHITE);  // S2 ▼
 
   // ── Menu mode hints ───────────────────────────────────────────────────
   if (NorviOledDisplay::isMenuActive()) {
@@ -611,12 +617,10 @@ void NorviOledDisplay::drawMenuPage() {
 
   // ── Dynamic menu items ─────────────────────────────────────────────────
   char modeBuf[14];
-  snprintf(modeBuf, sizeof(modeBuf), " Mode: %s",
-           operationModeNode.getMode().c_str());
+  snprintf(modeBuf, sizeof(modeBuf), " Mode: %s", operationModeNode.getMode().c_str());
 
   char pumpBuf[14];
-  snprintf(pumpBuf, sizeof(pumpBuf), " Pump: %s",
-           poolPumpNode.getSwitch() ? "on " : "off");
+  snprintf(pumpBuf, sizeof(pumpBuf), " Pump: %s", poolPumpNode.getSwitch() ? "on " : "off");
 
   const char *exitItem = "  Exit menu";
 
@@ -660,8 +664,7 @@ static void drawProgressBar() {
   }
 
   // Only show on SENSOR_SETUP page in IDLE state with both sensors done
-  if (NorviOledDisplay::getCurrentPage() != NorviOledDisplay::Page::SENSOR_SETUP
-      || NorviOledDisplay::isSetupActive()) {
+  if (NorviOledDisplay::getCurrentPage() != NorviOledDisplay::Page::SENSOR_SETUP || NorviOledDisplay::isSetupActive()) {
     return;
   }
 

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -359,7 +359,7 @@ static void drawButtonHints() {
 
   // ── S1 hint (top) ───────────────────────────────────────────────────────
   dspFillTriangle(121, 14, 125, 20, 117, 20, SSD1306_WHITE);
-  dspCursor(99, 14);
+  dspCursor(86, 14);
   if (selSens || selRole) {
     display.print(F("up"));
   } else if (page == NorviOledDisplay::Page::MAIN) {
@@ -370,7 +370,7 @@ static void drawButtonHints() {
 
   // ── S2 hint (middle) ────────────────────────────────────────────────────
   dspFillTriangle(117, 27, 125, 27, 121, 33, SSD1306_WHITE);
-  dspCursor(99, 27);
+  dspCursor(83, 27);
   if (selSens || selRole) {
     display.print(F("dn"));
   } else {
@@ -380,11 +380,11 @@ static void drawButtonHints() {
   // ── S3 hint (bottom) ────────────────────────────────────────────────────
   if (page == NorviOledDisplay::Page::MAIN) {
     dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
-    dspCursor(99, 40);
+    dspCursor(80, 40);
     display.print(F("menu"));
   } else if (page == NorviOledDisplay::Page::SENSOR_SETUP) {
     dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
-    dspCursor(99, 40);
+    dspCursor(80, 40);
     if (selSens) {
       display.print(F("select"));
     } else if (selRole) {
@@ -883,11 +883,11 @@ void NorviOledDisplay::drawFooter() {
   }
 
   // ── Firmware version ──────────────────────────────────────────────────
-  dspCursor(68, 56);
+  dspCursor(78, 56);
   display.print(F("v" FW_VERSION));
 
   // ── Page number (X/Y format) ─────────────────────────────────────────
-  dspCursor(110, 56);
+  dspCursor(112, 56);
   {
     uint8_t pageNum = static_cast<uint8_t>(currentPage_) + 1;
     uint8_t maxPage = static_cast<uint8_t>(Page::SENSOR_SETUP);

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -235,7 +235,8 @@ void NorviOledDisplay::loop() {
 void NorviOledDisplay::previousPage() {
   uint8_t cur = static_cast<uint8_t>(currentPage_);
   if (cur == 0) {
-    currentPage_ = static_cast<Page>(maxNavPage());
+    // Wrap: MAIN → WIFI_SETUP (skip SENSOR_SETUP in backward cycle)
+    currentPage_ = Page::WIFI_SETUP;
   } else {
     currentPage_ = static_cast<Page>(cur - 1);
   }
@@ -353,7 +354,6 @@ static void drawButtonHints() {
   dspVLine(125, 14, 34, SSD1306_WHITE);
 
   const auto page = NorviOledDisplay::getCurrentPage();
-  const bool setup = NorviOledDisplay::isSetupActive();
   const bool selSens = NorviOledDisplay::isSelectSensorStep();
   const bool selRole = NorviOledDisplay::isSelectRoleStep();
 
@@ -362,8 +362,10 @@ static void drawButtonHints() {
   dspCursor(99, 14);
   if (selSens || selRole) {
     display.print(F("up"));
+  } else if (page == NorviOledDisplay::Page::MAIN) {
+    display.print(F("wrap"));
   } else {
-    display.print(F("nxt"));
+    display.print(F("prev"));
   }
 
   // ── S2 hint (middle) ────────────────────────────────────────────────────
@@ -372,23 +374,26 @@ static void drawButtonHints() {
   if (selSens || selRole) {
     display.print(F("dn"));
   } else {
-    display.print(F("nxt"));
+    display.print(F("next"));
   }
 
   // ── S3 hint (bottom) ────────────────────────────────────────────────────
-  dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
-  dspCursor(99, 40);
-  if (setup && page == NorviOledDisplay::Page::SENSOR_SETUP) {
+  if (page == NorviOledDisplay::Page::MAIN) {
+    dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
+    dspCursor(99, 40);
+    display.print(F("menu"));
+  } else if (page == NorviOledDisplay::Page::SENSOR_SETUP) {
+    dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
+    dspCursor(99, 40);
     if (selSens) {
-      display.print(F("ok"));
+      display.print(F("select"));
     } else if (selRole) {
-      display.print(F("set"));
+      display.print(F("assign"));
     } else {
-      display.print(F("ok"));
+      display.print(F("setup"));
     }
-  } else {
-    display.print(F("ok"));
   }
+  // Other info pages: no S3 action — hint is intentionally omitted
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -878,12 +883,18 @@ void NorviOledDisplay::drawFooter() {
   }
 
   // ── Firmware version ──────────────────────────────────────────────────
-  dspCursor(76, 56);
+  dspCursor(68, 56);
   display.print(F("v" FW_VERSION));
 
-  // ── Page number ──────────────────────────────────────────────────────
-  dspCursor(118, 56);
-  display.print(static_cast<uint8_t>(currentPage_) + 1);
+  // ── Page number (X/Y format) ─────────────────────────────────────────
+  dspCursor(110, 56);
+  {
+    uint8_t pageNum = static_cast<uint8_t>(currentPage_) + 1;
+    uint8_t maxPage = static_cast<uint8_t>(Page::SENSOR_SETUP);
+    char buf[8];
+    snprintf(buf, sizeof(buf), "%d/%d", pageNum, maxPage);
+    display.print(buf);
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -547,8 +547,10 @@ static void drawButtonHints() {
   // ── S1 hint (top) ───────────────────────────────────────────────────────
   dspFillTriangle(121, 14, 125, 20, 117, 20, SSD1306_WHITE);
   dspCursor(86, 14);
-  if (selSens || selRole) {
+  if (selSens) {
     display.print(F("up"));
+  } else if (selRole) {
+    display.print(F("Solar"));
   } else if (page == NorviOledDisplay::Page::MAIN) {
     display.print(F("wrap"));
   } else {
@@ -558,8 +560,10 @@ static void drawButtonHints() {
   // ── S2 hint (middle) ────────────────────────────────────────────────────
   dspFillTriangle(117, 27, 125, 27, 121, 33, SSD1306_WHITE);
   dspCursor(83, 27);
-  if (selSens || selRole) {
+  if (selSens) {
     display.print(F("dn"));
+  } else if (selRole) {
+    display.print(F(" Pool"));
   } else {
     display.print(F("next"));
   }
@@ -861,15 +865,12 @@ void NorviOledDisplay::drawQrCodePage() {
   url += '/';
 
   if (NetworkManager::isWiFiConnected()) {
-    // ── WiFi connected: no QR (too small to scan), show IP prominently ──
+    // ── WiFi connected: show IP prominently (text size 1) ─────────────
     dspCursor(0, 0);
     display.print(F("Web Interface:"));
-    dspCursor(0, 12);
-    display.setTextSize(2);
-    dspCursor(4, 24);
+    dspCursor(0, 14);
     display.print(WiFi.localIP().toString());
-    display.setTextSize(1);
-    dspCursor(0, 50);
+    dspCursor(0, 28);
     display.print(F("Open in your browser"));
   } else {
     // ── No WiFi: show QR code as large as possible ─────────────────────
@@ -1222,12 +1223,14 @@ void NorviOledDisplay::updateBurnInOffset() {
   }
   lastBurnInShiftMs_ = now;
 
-  // Cycle: (0,0) → (2,0) → (2,2) → (0,2) → (0,0)
+  // Cycle: (0,0) → (2,0) → (2,1) → (0,1) → (0,0)
+  // Y-offset is 1 instead of 2 because the 64-pixel height leaves no
+  // room for a 2px downward shift on bottom-aligned content (footer).
   if (burnInDx_ == 0 && burnInDy_ == 0) {
     burnInDx_ = 2;
   } else if (burnInDx_ == 2 && burnInDy_ == 0) {
-    burnInDy_ = 2;
-  } else if (burnInDx_ == 2 && burnInDy_ == 2) {
+    burnInDy_ = 1;
+  } else if (burnInDx_ == 2 && burnInDy_ == 1) {
     burnInDx_ = 0;
   } else {
     burnInDx_ = 0;
@@ -1265,15 +1268,6 @@ void NorviOledDisplay::getMapping(uint8_t solarAddr[8], uint8_t poolAddr[8]) {
 }
 
 void NorviOledDisplay::setupSelectPrevious() {
-  // ── Cancel: at first item, go back to IDLE ──────────────────────────
-  if (setupStep_ == SetupStep::SELECT_SENSOR && setupSelectedDev_ == 0) {
-    setupStep_ = SetupStep::IDLE;
-    setupSelectedDev_ = 0;
-    forceRedraw_ = true;
-    Serial.println("→ Sensor setup cancelled, back to IDLE");
-    return;
-  }
-
   uint8_t devCount = solarTemperatureNode.getDeviceCount();
   if (devCount > 2) {
     devCount = 2;
@@ -1301,8 +1295,13 @@ void NorviOledDisplay::setupSelectNext() {
   forceRedraw_ = true;
 }
 
-void NorviOledDisplay::setupToggleRole() {
-  setupRoleIsSolar_ = !setupRoleIsSolar_;
+void NorviOledDisplay::setupSelectSolar() {
+  setupRoleIsSolar_ = true;
+  forceRedraw_ = true;
+}
+
+void NorviOledDisplay::setupSelectPool() {
+  setupRoleIsSolar_ = false;
   forceRedraw_ = true;
 }
 

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -402,13 +402,14 @@ void NorviOledDisplay::drawPage() {
     break;
   case Page::QRCODE:
     drawQrCodePage();
-    drawButtonHints();
+    if (!NetworkManager::isWiFiConnected()) {
+      drawButtonHints();  // Only on non-connected QR page (hints overlap IP)
+    }
     drawFooter();
     break;
   case Page::WIFI_SETUP:
     drawWiFiSetupPage();
-    // No button hints — full page usage for QR
-    drawFooter();
+    // Full page usage: no hints, no shared footer
     break;
   case Page::SENSOR_SETUP:
     drawSensorSetupPage();
@@ -766,30 +767,39 @@ void NorviOledDisplay::drawQrCodePage() {
   }
   url += '/';
 
-  // Show URL at top
-  dspCursor(0, 0);
-  if (url.length() <= 20) {
-    display.print(url);
+  if (NetworkManager::isWiFiConnected()) {
+    // ── WiFi connected: no QR (too small to scan), show IP prominently ──
+    dspCursor(0, 0);
+    display.print(F("Web Interface:"));
+    dspCursor(0, 12);
+    display.setTextSize(2);
+    dspCursor(4, 24);
+    display.print(WiFi.localIP().toString());
+    display.setTextSize(1);
+    dspCursor(0, 50);
+    display.print(F("Open in your browser"));
   } else {
-    display.print(url.substring(0, 20));
-  }
+    // ── No WiFi: show QR code as large as possible ─────────────────────
+    dspCursor(0, 0);
+    display.print(F("Scan QR or enter URL"));
 
-  // Generate QR code (version 1 = 21×21)
-  static constexpr size_t kQrBufferSize = 75;
-  uint8_t qrData[kQrBufferSize];
-  QRCode qr;
-  qrcode_initText(&qr, qrData, 1, 0, url.c_str());
+    // Generate QR code (version 1 = 21×21)
+    static constexpr size_t kQrBufferSize = 75;
+    uint8_t qrData[kQrBufferSize];
+    QRCode qr;
+    qrcode_initText(&qr, qrData, 1, 0, url.c_str());
 
-  // Draw QR centered, 2px per module
-  static constexpr uint8_t SCALE = 2;
-  const uint8_t qrPx = qr.size * SCALE;
-  const uint8_t xOff = (128 - qrPx) / 2;
-  const uint8_t yOff = 8;
+    // Draw QR centered, max scale that fits (2px per module = 42×42)
+    static constexpr uint8_t SCALE = 2;
+    const uint8_t qrPx = qr.size * SCALE;
+    const uint8_t xOff = (128 - qrPx) / 2;
+    const uint8_t yOff = 10;
 
-  for (uint8_t y = 0; y < qr.size; y++) {
-    for (uint8_t x = 0; x < qr.size; x++) {
-      if (qrcode_getModule(&qr, x, y)) {
-        dspFillRect(xOff + x * SCALE, yOff + y * SCALE, SCALE, SCALE, SSD1306_WHITE);
+    for (uint8_t y = 0; y < qr.size; y++) {
+      for (uint8_t x = 0; x < qr.size; x++) {
+        if (qrcode_getModule(&qr, x, y)) {
+          dspFillRect(xOff + x * SCALE, yOff + y * SCALE, SCALE, SCALE, SSD1306_WHITE);
+        }
       }
     }
   }
@@ -810,70 +820,65 @@ void NorviOledDisplay::drawWiFiSetupPage() {
   display.print(F(" WiFi Setup"));
   dspHLine(0, 9, 128, SSD1306_WHITE);
 
-  // ── Hint text ──────────────────────────────────────────────────────────
-  dspCursor(0, 12);
-  if (NetworkManager::isApMode()) {
-    display.print(F(" Connect to WiFi:"));
-    dspCursor(0, 20);
-    {
-      String apName = WiFi.softAPSSID();
-      if (apName.length() > 15) {
-        apName = apName.substring(0, 15);
-      }
-      display.print(apName);
-    }
-    dspCursor(0, 29);
-    display.print(F(" Open browser to:"));
-    dspCursor(0, 37);
-    display.print(F(" 192.168.4.1"));
-  } else if (NetworkManager::isWiFiConnected()) {
+  if (NetworkManager::isWiFiConnected()) {
+    // ── WiFi already configured: no QR, just info ─────────────────────
     dspCursor(0, 20);
     display.print(F(" WiFi configured!"));
     dspCursor(0, 29);
     display.print(F(" IP: "));
     display.print(WiFi.localIP().toString());
+    dspCursor(0, 46);
+    display.print(F(" Open browser to IP"));
   } else {
-    dspCursor(0, 20);
-    display.print(F(" Connect to WiFi,"));
-    dspCursor(0, 28);
-    display.print(F(" then browse to"));
-    dspCursor(0, 36);
-    display.print(F(" http://this-device/"));
-  }
+    // ── No WiFi / AP mode: maximal QR code ─────────────────────────────
+    String url = "http://";
+    if (NetworkManager::isApMode()) {
+      url += F("192.168.4.1");
+      // Show AP SSID line above QR
+      dspCursor(0, 12);
+      {
+        String apName = WiFi.softAPSSID();
+        if (apName.length() > 14) {
+          apName = apName.substring(0, 14);
+        }
+        display.print(F("AP: "));
+        display.print(apName);
+      }
+    } else {
+      url += F("192.168.4.1");
+      dspCursor(0, 12);
+      display.print(F("Connect to WiFi, then"));
+    }
+    url += '/';
 
-  // ── QR code (compact, top-right area) ─────────────────────────────────
-  String url = "http://";
-  if (NetworkManager::isApMode()) {
-    url += F("192.168.4.1");
-  } else if (NetworkManager::isWiFiConnected()) {
-    url += WiFi.localIP().toString();
-  } else {
-    url += F("192.168.4.1");  // Fallback to AP IP
-  }
-  url += '/';
+    // Generate QR at max usable scale (2px = 42×42)
+    static constexpr size_t kQrBufSize = 75;
+    uint8_t qrBuf[kQrBufSize];
+    QRCode qr;
+    qrcode_initText(&qr, qrBuf, 1, 0, url.c_str());
 
-  // Small QR code (version 1, 1px scale) in top-right corner
-  static constexpr size_t kQrBufSize = 75;
-  uint8_t qrBuf[kQrBufSize];
-  QRCode qr;
-  qrcode_initText(&qr, qrBuf, 1, 0, url.c_str());
+    static constexpr uint8_t QR_SCALE = 2;
+    const uint8_t qrPx = qr.size * QR_SCALE;
+    const uint8_t qrX = (128 - qrPx) / 2;
+    const uint8_t qrY = 20;
 
-  static constexpr uint8_t QR_SCALE = 1;
-  const uint8_t qrPx = qr.size * QR_SCALE;
-  const uint8_t qrX = 128 - qrPx - 2;
-  const uint8_t qrY = 10;
-
-  for (uint8_t y = 0; y < qr.size; y++) {
-    for (uint8_t x = 0; x < qr.size; x++) {
-      if (qrcode_getModule(&qr, x, y)) {
-        dspFillRect(qrX + x * QR_SCALE, qrY + y * QR_SCALE, QR_SCALE, QR_SCALE, SSD1306_WHITE);
+    for (uint8_t y = 0; y < qr.size; y++) {
+      for (uint8_t x = 0; x < qr.size; x++) {
+        if (qrcode_getModule(&qr, x, y)) {
+          dspFillRect(qrX + x * QR_SCALE, qrY + y * QR_SCALE, QR_SCALE, QR_SCALE, SSD1306_WHITE);
+        }
       }
     }
-  }
 
-  // ── Footer hint ────────────────────────────────────────────────────────
-  dspCursor(0, 50);
-  display.print(F("Scan QR or enter URL"));
+    // ── Instruction text below QR ────────────────────────────────────
+    if (NetworkManager::isApMode()) {
+      dspCursor(0, 56);
+      display.print(F("Browse to 192.168.4.1"));
+    } else {
+      dspCursor(0, 56);
+      display.print(F("browse to 192.168.4.1"));
+    }
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -165,6 +165,101 @@ static void dspInvertedText(int16_t x, int16_t y, const __FlashStringHelper *tex
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Scrolling text helper — auto-scrolls horizontally if text exceeds maxWidth
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Pauses 2 s at start, scrolls left at 25 px/s, pauses 1 s at end,
+// rewinds at 50 px/s. Animation resets when page or text content changes.
+
+static uint32_t scrollAnimStartMs_ = 0;
+static int8_t scrollPhase_ = 0;      // 0=pause 1=scroll-L 2=pause 3=rewind
+static int16_t scrollOffset_ = 0;
+
+/**
+ * @brief Draw text with horizontal scrolling if it exceeds @p maxWidth.
+ *
+ * The display driver clips at 0..127 automatically, so drawing at
+ * x - offset achieves a hardware-accelerated left scroll without
+ * manual clipping.
+ */
+static void drawScrollingText(int16_t x, int16_t y, const char *text, int16_t maxWidth) {
+  if (!text || text[0] == '\0') return;
+
+  int16_t x1, y1;
+  uint16_t textW, h;
+  display.getTextBounds(text, 0, y, &x1, &y1, &textW, &h);
+
+  if (textW <= (uint16_t)maxWidth) {
+    dspCursor(x, y);
+    display.print(text);
+    return;
+  }
+
+  // State tracking — read current page once
+  static int16_t lastTextW = 0;
+  static NorviOledDisplay::Page scrollPage_ = static_cast<NorviOledDisplay::Page>(0xFF);
+  const auto curPage = NorviOledDisplay::getCurrentPage();
+
+  // Reset animation on page or text width change
+  if (textW != lastTextW) {
+    scrollPhase_ = 0;
+    scrollOffset_ = 0;
+    scrollAnimStartMs_ = millis();
+    lastTextW = textW;
+  } else if (curPage != scrollPage_) {
+    // Re-sync when navigating to a different page mid-scroll
+    scrollPhase_ = 0;
+    scrollOffset_ = 0;
+    scrollAnimStartMs_ = millis();
+    scrollPage_ = curPage;
+  }
+
+  const uint32_t now = millis();
+  const int16_t scrollRange = textW - maxWidth;
+  const uint32_t elapsed = now - scrollAnimStartMs_;
+
+  switch (scrollPhase_) {
+  case 0:  // Pause at start — full text visible entering from right
+    scrollOffset_ = 0;
+    if (elapsed >= 2000) { scrollPhase_ = 1; scrollAnimStartMs_ = now; }
+    break;
+
+  case 1:  // Scroll left at 25 px/s
+    scrollOffset_ = static_cast<int16_t>(elapsed * 25 / 1000);
+    if (scrollOffset_ >= scrollRange) {
+      scrollOffset_ = scrollRange;
+      scrollPhase_ = 2;
+      scrollAnimStartMs_ = now;
+    }
+    break;
+
+  case 2:  // Pause at end — last characters visible
+    if (elapsed >= 1000) { scrollPhase_ = 3; scrollAnimStartMs_ = now; }
+    break;
+
+  case 3:  // Rewind right at 50 px/s
+    scrollOffset_ = scrollRange - static_cast<int16_t>(elapsed * 50 / 1000);
+    if (scrollOffset_ <= 0) {
+      scrollOffset_ = 0;
+      scrollPhase_ = 0;
+      scrollAnimStartMs_ = now;
+    }
+    break;
+  }
+
+  dspCursor(x - scrollOffset_, y);
+  display.print(text);
+}
+
+/// Overload for PROGMEM / Flash strings.
+static void drawScrollingText(int16_t x, int16_t y, const __FlashStringHelper *text, int16_t maxWidth) {
+  char buf[64];
+  strncpy_P(buf, reinterpret_cast<PGM_P>(text), sizeof(buf) - 1);
+  buf[sizeof(buf) - 1] = '\0';
+  drawScrollingText(x, y, buf, maxWidth);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // begin() — Initialization
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -669,18 +764,14 @@ void NorviOledDisplay::drawNetworkPage() {
   display.print(F(" Network Status"));
   dspHLine(0, 9, 128, SSD1306_WHITE);
 
-  // ── WiFi SSID ───────────────────────────────────────────────────────────
+  // ── WiFi SSID (scrolls if too long) ────────────────────────────────────
   dspCursor(0, 13);
   display.print(F("WiFi: "));
   if (NetworkManager::isWiFiConnected()) {
     if (NetworkManager::isApMode()) {
       display.print(F("AP MODE"));
     } else {
-      String ssid = WiFi.SSID();
-      if (ssid.length() > 9) {
-        ssid = ssid.substring(0, 9);
-      }
-      display.print(ssid);
+      drawScrollingText(36, 13, WiFi.SSID().c_str(), 128 - 36);
     }
   } else {
     display.print(F("---"));
@@ -780,8 +871,7 @@ void NorviOledDisplay::drawQrCodePage() {
     display.print(F("Open in your browser"));
   } else {
     // ── No WiFi: show QR code as large as possible ─────────────────────
-    dspCursor(0, 0);
-    display.print(F("Scan QR or enter URL"));
+    drawScrollingText(0, 0, url.c_str(), 128);
 
     // Generate QR code (version 1 = 21×21)
     static constexpr size_t kQrBufferSize = 75;
@@ -834,15 +924,11 @@ void NorviOledDisplay::drawWiFiSetupPage() {
     String url = "http://";
     if (NetworkManager::isApMode()) {
       url += F("192.168.4.1");
-      // Show AP SSID line above QR
+      // Show AP SSID line above QR (scrolls if too long)
       dspCursor(0, 12);
       {
-        String apName = WiFi.softAPSSID();
-        if (apName.length() > 14) {
-          apName = apName.substring(0, 14);
-        }
         display.print(F("AP: "));
-        display.print(apName);
+        drawScrollingText(24, 12, WiFi.softAPSSID().c_str(), 128 - 24);
       }
     } else {
       url += F("192.168.4.1");

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -72,6 +72,9 @@ bool NorviOledDisplay::setupRoleIsSolar_ = true;
 
 bool NorviOledDisplay::firstBootDone_ = false;
 
+NorviOledDisplay::MenuItem NorviOledDisplay::menuSelection_ = MenuItem::MODE;
+bool NorviOledDisplay::menuActive_ = false;
+
 // ── SSD1306 display instance (128×64, I2C, address 0x3C) ─────────────────
 
 static Adafruit_SSD1306 display(128, 64, &Wire, -1);
@@ -207,8 +210,14 @@ void NorviOledDisplay::begin() {
 void NorviOledDisplay::loop() {
   const uint32_t now = millis();
 
-  // ── Auto-return to MAIN after idle timeout ──────────────────────────
-  if (currentPage_ != Page::MAIN && !isSetupActive() && (now - lastButtonPressMs_ >= AUTO_RETURN_MS)) {
+  // ── Auto-return after idle timeout ───────────────────────────────────
+  if (menuActive_ && (now - lastButtonPressMs_ >= 30000)) {
+    // Menu: 30 s idle → close menu
+    menuActive_ = false;
+    forceRedraw_ = true;
+  } else if (!isSetupActive() && currentPage_ != Page::MAIN
+             && (now - lastButtonPressMs_ >= AUTO_RETURN_MS)) {
+    // Info pages (non-MAIN): 60 s idle → MAIN
     currentPage_ = Page::MAIN;
     forceRedraw_ = true;
   }
@@ -298,12 +307,57 @@ void NorviOledDisplay::confirmAction() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Action menu navigation
+// ═══════════════════════════════════════════════════════════════════════════
+
+void NorviOledDisplay::enterMenu() {
+  menuActive_ = true;
+  menuSelection_ = MenuItem::MODE;
+  forceRedraw_ = true;
+  lastButtonPressMs_ = millis();
+}
+
+void NorviOledDisplay::exitMenu() {
+  menuActive_ = false;
+  forceRedraw_ = true;
+  lastButtonPressMs_ = millis();
+}
+
+void NorviOledDisplay::menuNext() {
+  uint8_t cur = static_cast<uint8_t>(menuSelection_);
+  cur = (cur + 1) % 3;  // MODE → PUMP → EXIT → MODE
+  menuSelection_ = static_cast<MenuItem>(cur);
+  forceRedraw_ = true;
+  lastButtonPressMs_ = millis();
+}
+
+void NorviOledDisplay::menuPrevious() {
+  uint8_t cur = static_cast<uint8_t>(menuSelection_);
+  if (cur == 0) {
+    cur = 2;  // wrap: MODE → EXIT
+  } else {
+    cur--;
+  }
+  menuSelection_ = static_cast<MenuItem>(cur);
+  forceRedraw_ = true;
+  lastButtonPressMs_ = millis();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // drawPage() — Dispatch
 // ═══════════════════════════════════════════════════════════════════════════
 
 void NorviOledDisplay::drawPage() {
   display.clearDisplay();
   display.setTextColor(SSD1306_WHITE);
+
+  // ── Action menu overlay ─────────────────────────────────────────────
+  if (menuActive_) {
+    drawMenuPage();
+    drawButtonHints();
+    drawFooter();
+    return;
+  }
 
   switch (currentPage_) {
   case Page::MAIN:
@@ -353,12 +407,23 @@ void NorviOledDisplay::drawPage() {
 static void drawButtonHints() {
   dspVLine(125, 14, 34, SSD1306_WHITE);
 
+  // Draw button symbols (always present)
+  dspFillTriangle(121, 14, 125, 20, 117, 20, SSD1306_WHITE);  // S1 ▲
+  dspFillTriangle(117, 27, 125, 27, 121, 33, SSD1306_WHITE);   // S2 ▼
+
+  // ── Menu mode hints ───────────────────────────────────────────────────
+  if (NorviOledDisplay::isMenuActive()) {
+    dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
+    dspCursor(99, 40);
+    display.print(F("sel"));
+    return;
+  }
+
   const auto page = NorviOledDisplay::getCurrentPage();
   const bool selSens = NorviOledDisplay::isSelectSensorStep();
   const bool selRole = NorviOledDisplay::isSelectRoleStep();
 
-  // ── S1 hint (top) ───────────────────────────────────────────────────────
-  dspFillTriangle(121, 14, 125, 20, 117, 20, SSD1306_WHITE);
+  // ── S1 label (top) ─────────────────────────────────────────────────────
   dspCursor(99, 14);
   if (selSens || selRole) {
     display.print(F("up"));
@@ -368,8 +433,7 @@ static void drawButtonHints() {
     display.print(F("prev"));
   }
 
-  // ── S2 hint (middle) ────────────────────────────────────────────────────
-  dspFillTriangle(117, 27, 125, 27, 121, 33, SSD1306_WHITE);
+  // ── S2 label (middle) ──────────────────────────────────────────────────
   dspCursor(99, 27);
   if (selSens || selRole) {
     display.print(F("dn"));
@@ -377,7 +441,7 @@ static void drawButtonHints() {
     display.print(F("next"));
   }
 
-  // ── S3 hint (bottom) ────────────────────────────────────────────────────
+  // ── S3 label (bottom) ──────────────────────────────────────────────────
   if (page == NorviOledDisplay::Page::MAIN) {
     dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
     dspCursor(99, 40);
@@ -394,6 +458,68 @@ static void drawButtonHints() {
     }
   }
   // Other info pages: no S3 action — hint is intentionally omitted
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Action menu (MAIN → S3)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+//  ┌──────────────────────┬──────┐
+//  │ Menu                 │      │
+//  │──────────────────────│ S1 ▲│
+//  │ ▓ Mode: auto         │ S2 ▼│
+//  │   Pump: off          │ S3 ●│ sel
+//  │   Exit menu          │      │
+//  ├──────────────────────┴──────┤
+//  │ AUTO  12:30  v4.0.2     1/5│
+//  └─────────────────────────────┘
+
+void NorviOledDisplay::drawMenuPage() {
+  display.setTextSize(1);
+
+  // ── Title ──────────────────────────────────────────────────────────────
+  dspCursor(0, 0);
+  display.print(F(" Menu"));
+  dspHLine(0, 9, 128, SSD1306_WHITE);
+
+  // ── Dynamic menu items ─────────────────────────────────────────────────
+  char modeBuf[14];
+  snprintf(modeBuf, sizeof(modeBuf), " Mode: %s",
+           operationModeNode.getMode().c_str());
+
+  char pumpBuf[14];
+  snprintf(pumpBuf, sizeof(pumpBuf), " Pump: %s",
+           poolPumpNode.getSwitch() ? "on " : "off");
+
+  const char *exitItem = "  Exit menu";
+
+  // ── Render items (12 px line height) ──────────────────────────────────
+  static constexpr uint8_t Y0 = 14;
+  static constexpr uint8_t LH = 12;
+
+  // Item 1: Mode
+  if (menuSelection_ == MenuItem::MODE) {
+    dspInvertedText(4, Y0, modeBuf);
+  } else {
+    dspCursor(4, Y0);
+    display.print(modeBuf);
+  }
+
+  // Item 2: Pump
+  if (menuSelection_ == MenuItem::PUMP) {
+    dspInvertedText(4, Y0 + LH, pumpBuf);
+  } else {
+    dspCursor(4, Y0 + LH);
+    display.print(pumpBuf);
+  }
+
+  // Item 3: Exit
+  if (menuSelection_ == MenuItem::EXIT) {
+    dspInvertedText(4, Y0 + 2 * LH, exitItem);
+  } else {
+    dspCursor(4, Y0 + 2 * LH);
+    display.print(exitItem);
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -703,7 +829,15 @@ void NorviOledDisplay::drawWiFiSetupPage() {
 void NorviOledDisplay::drawSensorSetupPage() {
   display.setTextSize(1);
   dspCursor(0, 0);
-  display.print(F(" Sensor Setup"));
+  display.print(F(" Setup"));
+  // Step indicator [1/2] or [2/2] when wizard is active
+  if (setupStep_ != SetupStep::IDLE) {
+    char stepBuf[8];
+    uint8_t stepNum = (setupStep_ == SetupStep::SELECT_SENSOR) ? 1 : 2;
+    snprintf(stepBuf, sizeof(stepBuf), " [%d/2]", stepNum);
+    dspCursor(60, 0);
+    display.print(stepBuf);
+  }
   dspHLine(0, 9, 128, SSD1306_WHITE);
 
   const uint8_t devCount = solarTemperatureNode.getDeviceCount();
@@ -970,6 +1104,15 @@ void NorviOledDisplay::getMapping(uint8_t solarAddr[8], uint8_t poolAddr[8]) {
 }
 
 void NorviOledDisplay::setupSelectPrevious() {
+  // ── Cancel: at first item, go back to IDLE ──────────────────────────
+  if (setupStep_ == SetupStep::SELECT_SENSOR && setupSelectedDev_ == 0) {
+    setupStep_ = SetupStep::IDLE;
+    setupSelectedDev_ = 0;
+    forceRedraw_ = true;
+    Serial.println("→ Sensor setup cancelled, back to IDLE");
+    return;
+  }
+
   uint8_t devCount = solarTemperatureNode.getDeviceCount();
   if (devCount > 2) {
     devCount = 2;

--- a/src/NorviOledDisplay.hpp
+++ b/src/NorviOledDisplay.hpp
@@ -147,8 +147,10 @@ public:
   static void setupSelectPrevious();
   /** @brief Move sensor selection down (next sensor). */
   static void setupSelectNext();
-  /** @brief Move role selection (Solar ↔ Pool). */
-  static void setupToggleRole();
+  /** @brief Select Solar role for the chosen sensor (S1). */
+  static void setupSelectSolar();
+  /** @brief Select Pool role for the chosen sensor (S2). */
+  static void setupSelectPool();
 
   /** @brief Assign the selected sensor with the chosen role. */
   static bool setupApplyAssignment();

--- a/src/NorviOledDisplay.hpp
+++ b/src/NorviOledDisplay.hpp
@@ -243,8 +243,8 @@ private:
   static bool setupRoleIsSolar_;  ///< true = Solar, false = Pool (in SELECT_ROLE)
 
   // ── Action menu state ──────────────────────────────────────────────
-  static bool menuActive_;          ///< True while action menu is shown
-  static MenuItem menuSelection_;   ///< Currently highlighted menu item
+  static bool menuActive_;         ///< True while action menu is shown
+  static MenuItem menuSelection_;  ///< Currently highlighted menu item
 
   // ── First-boot flow tracking ─────────────────────────────────────────
   static bool firstBootDone_;  ///< True after initial setup flow completed

--- a/src/NorviOledDisplay.hpp
+++ b/src/NorviOledDisplay.hpp
@@ -60,6 +60,15 @@ public:
     SELECT_ROLE,    ///< S1/S2 picks Solar or Pool, S3 assigns
   };
 
+  // ── Action menu items (MAIN page via S3) ────────────────────────────
+
+  /** @brief Items in the MAIN-page action menu. */
+  enum class MenuItem : std::uint8_t {
+    MODE = 0,  ///< Cycle operation mode
+    PUMP,      ///< Toggle pump on/off
+    EXIT       ///< Return to MAIN
+  };
+
   // ── Public API ───────────────────────────────────────────────────────
 
   /** @brief Initialize the OLED display + splash screen. */
@@ -80,6 +89,26 @@ public:
 
   /** @brief Confirm / action button (S3). */
   static void confirmAction();
+
+  // ── Action menu (MAIN page) ─────────────────────────────────────────
+
+  /** @brief Check if the action menu is active. */
+  static bool isMenuActive() { return menuActive_; }
+
+  /** @brief Get the currently selected menu item. */
+  static MenuItem getMenuSelection() { return menuSelection_; }
+
+  /** @brief Enter the action menu (from MAIN page). */
+  static void enterMenu();
+
+  /** @brief Exit the action menu, return to MAIN. */
+  static void exitMenu();
+
+  /** @brief Move menu selection to next item (down). */
+  static void menuNext();
+
+  /** @brief Move menu selection to previous item (up). */
+  static void menuPrevious();
 
   /** @brief Get the currently active page. */
   static Page getCurrentPage() { return currentPage_; }
@@ -152,6 +181,9 @@ private:
   /** @brief Draw WIFI_SETUP — captive portal info + QR. */
   static void drawWiFiSetupPage();
 
+  /** @brief Draw the action menu overlay (MAIN page). */
+  static void drawMenuPage();
+
   /** @brief Draw SENSOR_SETUP — address mapping wizard. */
   static void drawSensorSetupPage();
 
@@ -207,6 +239,10 @@ private:
   static uint8_t setupSolarAddr_[8];
   static uint8_t setupPoolAddr_[8];
   static bool setupRoleIsSolar_;  ///< true = Solar, false = Pool (in SELECT_ROLE)
+
+  // ── Action menu state ──────────────────────────────────────────────
+  static bool menuActive_;          ///< True while action menu is shown
+  static MenuItem menuSelection_;   ///< Currently highlighted menu item
 
   // ── First-boot flow tracking ─────────────────────────────────────────
   static bool firstBootDone_;  ///< True after initial setup flow completed

--- a/src/PoolController.cpp
+++ b/src/PoolController.cpp
@@ -292,57 +292,74 @@ auto PoolControllerContext::setup() -> void {
   NorviOledDisplay::begin();
   NorviButtonHandler::begin();
 
-  // Wire button callbacks (new navigation: S1=UP, S2=DOWN, S3=CONFIRM)
+  // Wire button callbacks (S1=UP, S2=DOWN, S3=ACTION)
   // ── S1 (UP) ───────────────────────────────────────────────────────────
   NorviButtonHandler::onButton1Press([]() {
-    if (NorviOledDisplay::isSelectSensorStep()) {
-      // Sensor selection: move to previous sensor
+    if (NorviOledDisplay::isMenuActive()) {
+      NorviOledDisplay::menuPrevious();
+    } else if (NorviOledDisplay::isSelectSensorStep()) {
       NorviOledDisplay::setupSelectPrevious();
       NorviOledDisplay::requestRedraw();
     } else if (NorviOledDisplay::isSelectRoleStep()) {
-      // Role selection: toggle Solar ↔ Pool
       NorviOledDisplay::setupToggleRole();
       NorviOledDisplay::requestRedraw();
     } else {
-      // Normal mode: previous page
       NorviOledDisplay::previousPage();
     }
   });
   // ── S2 (DOWN) ─────────────────────────────────────────────────────────
   NorviButtonHandler::onButton2Press([]() {
-    if (NorviOledDisplay::isSelectSensorStep()) {
-      // Sensor selection: move to next sensor
+    if (NorviOledDisplay::isMenuActive()) {
+      NorviOledDisplay::menuNext();
+    } else if (NorviOledDisplay::isSelectSensorStep()) {
       NorviOledDisplay::setupSelectNext();
       NorviOledDisplay::requestRedraw();
     } else if (NorviOledDisplay::isSelectRoleStep()) {
-      // Role selection: toggle Solar ↔ Pool
       NorviOledDisplay::setupToggleRole();
       NorviOledDisplay::requestRedraw();
     } else {
-      // Normal mode: next page
       NorviOledDisplay::nextPage();
     }
   });
   // ── S3 (CONFIRM) ──────────────────────────────────────────────────────
   NorviButtonHandler::onButton3Press([]() {
-    if (NorviOledDisplay::getCurrentPage() == NorviOledDisplay::Page::SENSOR_SETUP) {
-      // Sensor setup page: advance the state machine (IDLE→SELECT→ROLE→assign)
-      NorviOledDisplay::confirmAction();
-    } else {
-      // Normal mode: cycle operation mode
-      NorviOledDisplay::requestRedraw();
-      const String &currentMode = operationModeNode.getMode();
-      if (currentMode == "auto") {
-        operationModeNode.setMode("manu");
-      } else if (currentMode == "manu") {
-        operationModeNode.setMode("boost");
-      } else if (currentMode == "boost") {
-        operationModeNode.setMode("timer");
-      } else {
-        operationModeNode.setMode("auto");
+    if (NorviOledDisplay::isMenuActive()) {
+      // Execute selected menu action, then return to MAIN
+      NorviOledDisplay::Page prevPage = NorviOledDisplay::getCurrentPage();
+      switch (NorviOledDisplay::getMenuSelection()) {
+      case NorviOledDisplay::MenuItem::MODE: {
+        // Cycle operation mode
+        const String &currentMode = operationModeNode.getMode();
+        if (currentMode == "auto") {
+          operationModeNode.setMode("manu");
+        } else if (currentMode == "manu") {
+          operationModeNode.setMode("boost");
+        } else if (currentMode == "boost") {
+          operationModeNode.setMode("timer");
+        } else {
+          operationModeNode.setMode("auto");
+        }
+        Serial.printf("→ Mode switched to: %s\n", operationModeNode.getMode().c_str());
+        break;
       }
-      Serial.printf("→ Mode switched to: %s\n", operationModeNode.getMode().c_str());
+      case NorviOledDisplay::MenuItem::PUMP:
+        // Toggle pool pump
+        poolPumpNode.setSwitch(!poolPumpNode.getSwitch());
+        Serial.printf("→ Pump toggled: %s\n", poolPumpNode.getSwitch() ? "ON" : "OFF");
+        break;
+      case NorviOledDisplay::MenuItem::EXIT:
+        // No action — just exit
+        break;
+      }
+      NorviOledDisplay::exitMenu();
+    } else if (NorviOledDisplay::getCurrentPage() == NorviOledDisplay::Page::MAIN) {
+      // MAIN page: open action menu
+      NorviOledDisplay::enterMenu();
+    } else if (NorviOledDisplay::getCurrentPage() == NorviOledDisplay::Page::SENSOR_SETUP) {
+      // Sensor setup: advance the wizard
+      NorviOledDisplay::confirmAction();
     }
+    // Other info pages: S3 intentionally does nothing
   });
   // ── S3 long-press: save sensor mapping & reboot ───────────────────────
   NorviButtonHandler::onButton3LongPress([]() -> bool {

--- a/src/PoolController.cpp
+++ b/src/PoolController.cpp
@@ -308,7 +308,7 @@ auto PoolControllerContext::setup() -> void {
       NorviOledDisplay::setupSelectPrevious();
       NorviOledDisplay::requestRedraw();
     } else if (NorviOledDisplay::isSelectRoleStep()) {
-      NorviOledDisplay::setupToggleRole();
+      NorviOledDisplay::setupSelectSolar();
       NorviOledDisplay::requestRedraw();
     } else {
       NorviOledDisplay::previousPage();
@@ -322,7 +322,7 @@ auto PoolControllerContext::setup() -> void {
       NorviOledDisplay::setupSelectNext();
       NorviOledDisplay::requestRedraw();
     } else if (NorviOledDisplay::isSelectRoleStep()) {
-      NorviOledDisplay::setupToggleRole();
+      NorviOledDisplay::setupSelectPool();
       NorviOledDisplay::requestRedraw();
     } else {
       NorviOledDisplay::nextPage();


### PR DESCRIPTION
## Integration Branch: NORVI Display UX

Dieser PR vereint alle drei Display-Feature-PRs (#147, #148, #149) in einem Branch.

### Enthaltene Änderungen:

**#147 — Hint-Labels, Footer-Format und S1-Wrap**
- Button-Hints (S1/S2/S3 Label) rechts neben den Tasten
- Footer: Mode, Uhrzeit, WiFi-Icon, Version (v4.0.2), Seitenzahl (X/Y)
- S1 wrappt auf MAIN zu WIFI_SETUP statt SENSOR_SETUP
- Version-Text bei x=78 (rechts vom WiFi-Icon), Page bei x=112
- Hint-Labels bei x=86/83/80 (vor Button-Glyphen bei x=117)

**#148 — Aktionsmenü, Wizard-Cancel und Schritt-Indikator**
- Action Menu auf MAIN: S3 öffnet Menü (Mode/Pump/Exit)
- SENSOR_SETUP Wizard mit Schritt-Anzeige [1/2], [2/2]
- S3 = confirm/select, S1/S2 = navigieren

**#149 — Long-Press-Fortschrittsbalken und Auto-Return-Warnung**
- Visueller Fortschrittsbalken bei Long-Press (2s)
- Auto-Return nach 60s Inaktivität mit Countdown-Warnung
- Auto-Return unterdrückt bei laufendem Wizard oder Long-Press

### Hotfixes (auf diesem Branch)
- ADC-Thresholds zurück auf Original (NoPress>3800, B1:200-1200, etc.)
- Sensor-Zuordnung: S1=Solar, S2=Pool (statt beide toggle)
- Hints zeigen "Solar"/"Pool" auf SELECT_ROLE
- QR-Seite: IP in textSize 1, kein Footer-Overlap
- Burn-In Y-Offset 2→1 (kein abgeschnittenes Footer-Pixel mehr)