### PR TITLE
feat(display): Aktionsmenü, Wizard-Cancel und Schritt-Indikator

### DIFF
--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -235,7 +235,8 @@ void NorviOledDisplay::loop() {
 void NorviOledDisplay::previousPage() {
   uint8_t cur = static_cast<uint8_t>(currentPage_);
   if (cur == 0) {
-    currentPage_ = static_cast<Page>(maxNavPage());
+    // Wrap: MAIN → WIFI_SETUP (skip SENSOR_SETUP in backward cycle)
+    currentPage_ = Page::WIFI_SETUP;
   } else {
     currentPage_ = static_cast<Page>(cur - 1);
   }
@@ -353,7 +354,6 @@ static void drawButtonHints() {
   dspVLine(125, 14, 34, SSD1306_WHITE);
 
   const auto page = NorviOledDisplay::getCurrentPage();
-  const bool setup = NorviOledDisplay::isSetupActive();
   const bool selSens = NorviOledDisplay::isSelectSensorStep();
   const bool selRole = NorviOledDisplay::isSelectRoleStep();
 
@@ -362,8 +362,10 @@ static void drawButtonHints() {
   dspCursor(99, 14);
   if (selSens || selRole) {
     display.print(F("up"));
+  } else if (page == NorviOledDisplay::Page::MAIN) {
+    display.print(F("wrap"));
   } else {
-    display.print(F("nxt"));
+    display.print(F("prev"));
   }
 
   // ── S2 hint (middle) ────────────────────────────────────────────────────
@@ -372,23 +374,26 @@ static void drawButtonHints() {
   if (selSens || selRole) {
     display.print(F("dn"));
   } else {
-    display.print(F("nxt"));
+    display.print(F("next"));
   }
 
   // ── S3 hint (bottom) ────────────────────────────────────────────────────
-  dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
-  dspCursor(99, 40);
-  if (setup && page == NorviOledDisplay::Page::SENSOR_SETUP) {
+  if (page == NorviOledDisplay::Page::MAIN) {
+    dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
+    dspCursor(99, 40);
+    display.print(F("menu"));
+  } else if (page == NorviOledDisplay::Page::SENSOR_SETUP) {
+    dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
+    dspCursor(99, 40);
     if (selSens) {
-      display.print(F("ok"));
+      display.print(F("select"));
     } else if (selRole) {
-      display.print(F("set"));
+      display.print(F("assign"));
     } else {
-      display.print(F("ok"));
+      display.print(F("setup"));
     }
-  } else {
-    display.print(F("ok"));
   }
+  // Other info pages: no S3 action — hint is intentionally omitted
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -878,12 +883,18 @@ void NorviOledDisplay::drawFooter() {
   }
 
   // ── Firmware version ──────────────────────────────────────────────────
-  dspCursor(76, 56);
+  dspCursor(68, 56);
   display.print(F("v" FW_VERSION));
 
-  // ── Page number ──────────────────────────────────────────────────────
-  dspCursor(118, 56);
-  display.print(static_cast<uint8_t>(currentPage_) + 1);
+  // ── Page number (X/Y format) ─────────────────────────────────────────
+  dspCursor(110, 56);
+  {
+    uint8_t pageNum = static_cast<uint8_t>(currentPage_) + 1;
+    uint8_t maxPage = static_cast<uint8_t>(Page::SENSOR_SETUP);
+    char buf[8];
+    snprintf(buf, sizeof(buf), "%d/%d", pageNum, maxPage);
+    display.print(buf);
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/NorviOledDisplay.cpp
+++ b/src/NorviOledDisplay.cpp
@@ -72,6 +72,9 @@ bool NorviOledDisplay::setupRoleIsSolar_ = true;
 
 bool NorviOledDisplay::firstBootDone_ = false;
 
+NorviOledDisplay::MenuItem NorviOledDisplay::menuSelection_ = MenuItem::MODE;
+bool NorviOledDisplay::menuActive_ = false;
+
 // ── SSD1306 display instance (128×64, I2C, address 0x3C) ─────────────────
 
 static Adafruit_SSD1306 display(128, 64, &Wire, -1);
@@ -207,8 +210,14 @@ void NorviOledDisplay::begin() {
 void NorviOledDisplay::loop() {
   const uint32_t now = millis();
 
-  // ── Auto-return to MAIN after idle timeout ──────────────────────────
-  if (currentPage_ != Page::MAIN && !isSetupActive() && (now - lastButtonPressMs_ >= AUTO_RETURN_MS)) {
+  // ── Auto-return after idle timeout ───────────────────────────────────
+  if (menuActive_ && (now - lastButtonPressMs_ >= 30000)) {
+    // Menu: 30 s idle → close menu
+    menuActive_ = false;
+    forceRedraw_ = true;
+  } else if (!isSetupActive() && currentPage_ != Page::MAIN
+             && (now - lastButtonPressMs_ >= AUTO_RETURN_MS)) {
+    // Info pages (non-MAIN): 60 s idle → MAIN
     currentPage_ = Page::MAIN;
     forceRedraw_ = true;
   }
@@ -298,12 +307,57 @@ void NorviOledDisplay::confirmAction() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Action menu navigation
+// ═══════════════════════════════════════════════════════════════════════════
+
+void NorviOledDisplay::enterMenu() {
+  menuActive_ = true;
+  menuSelection_ = MenuItem::MODE;
+  forceRedraw_ = true;
+  lastButtonPressMs_ = millis();
+}
+
+void NorviOledDisplay::exitMenu() {
+  menuActive_ = false;
+  forceRedraw_ = true;
+  lastButtonPressMs_ = millis();
+}
+
+void NorviOledDisplay::menuNext() {
+  uint8_t cur = static_cast<uint8_t>(menuSelection_);
+  cur = (cur + 1) % 3;  // MODE → PUMP → EXIT → MODE
+  menuSelection_ = static_cast<MenuItem>(cur);
+  forceRedraw_ = true;
+  lastButtonPressMs_ = millis();
+}
+
+void NorviOledDisplay::menuPrevious() {
+  uint8_t cur = static_cast<uint8_t>(menuSelection_);
+  if (cur == 0) {
+    cur = 2;  // wrap: MODE → EXIT
+  } else {
+    cur--;
+  }
+  menuSelection_ = static_cast<MenuItem>(cur);
+  forceRedraw_ = true;
+  lastButtonPressMs_ = millis();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // drawPage() — Dispatch
 // ═══════════════════════════════════════════════════════════════════════════
 
 void NorviOledDisplay::drawPage() {
   display.clearDisplay();
   display.setTextColor(SSD1306_WHITE);
+
+  // ── Action menu overlay ─────────────────────────────────────────────
+  if (menuActive_) {
+    drawMenuPage();
+    drawButtonHints();
+    drawFooter();
+    return;
+  }
 
   switch (currentPage_) {
   case Page::MAIN:
@@ -353,12 +407,23 @@ void NorviOledDisplay::drawPage() {
 static void drawButtonHints() {
   dspVLine(125, 14, 34, SSD1306_WHITE);
 
+  // Draw button symbols (always present)
+  dspFillTriangle(121, 14, 125, 20, 117, 20, SSD1306_WHITE);  // S1 ▲
+  dspFillTriangle(117, 27, 125, 27, 121, 33, SSD1306_WHITE);   // S2 ▼
+
+  // ── Menu mode hints ───────────────────────────────────────────────────
+  if (NorviOledDisplay::isMenuActive()) {
+    dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
+    dspCursor(99, 40);
+    display.print(F("sel"));
+    return;
+  }
+
   const auto page = NorviOledDisplay::getCurrentPage();
   const bool selSens = NorviOledDisplay::isSelectSensorStep();
   const bool selRole = NorviOledDisplay::isSelectRoleStep();
 
-  // ── S1 hint (top) ───────────────────────────────────────────────────────
-  dspFillTriangle(121, 14, 125, 20, 117, 20, SSD1306_WHITE);
+  // ── S1 label (top) ─────────────────────────────────────────────────────
   dspCursor(99, 14);
   if (selSens || selRole) {
     display.print(F("up"));
@@ -368,8 +433,7 @@ static void drawButtonHints() {
     display.print(F("prev"));
   }
 
-  // ── S2 hint (middle) ────────────────────────────────────────────────────
-  dspFillTriangle(117, 27, 125, 27, 121, 33, SSD1306_WHITE);
+  // ── S2 label (middle) ──────────────────────────────────────────────────
   dspCursor(99, 27);
   if (selSens || selRole) {
     display.print(F("dn"));
@@ -377,7 +441,7 @@ static void drawButtonHints() {
     display.print(F("next"));
   }
 
-  // ── S3 hint (bottom) ────────────────────────────────────────────────────
+  // ── S3 label (bottom) ──────────────────────────────────────────────────
   if (page == NorviOledDisplay::Page::MAIN) {
     dspFillRoundRect(117, 40, 8, 6, 1, SSD1306_WHITE);
     dspCursor(99, 40);
@@ -394,6 +458,68 @@ static void drawButtonHints() {
     }
   }
   // Other info pages: no S3 action — hint is intentionally omitted
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Action menu (MAIN → S3)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+//  ┌──────────────────────┬──────┐
+//  │ Menu                 │      │
+//  │──────────────────────│ S1 ▲│
+//  │ ▓ Mode: auto         │ S2 ▼│
+//  │   Pump: off          │ S3 ●│ sel
+//  │   Exit menu          │      │
+//  ├──────────────────────┴──────┤
+//  │ AUTO  12:30  v4.0.2     1/5│
+//  └─────────────────────────────┘
+
+void NorviOledDisplay::drawMenuPage() {
+  display.setTextSize(1);
+
+  // ── Title ──────────────────────────────────────────────────────────────
+  dspCursor(0, 0);
+  display.print(F(" Menu"));
+  dspHLine(0, 9, 128, SSD1306_WHITE);
+
+  // ── Dynamic menu items ─────────────────────────────────────────────────
+  char modeBuf[14];
+  snprintf(modeBuf, sizeof(modeBuf), " Mode: %s",
+           operationModeNode.getMode().c_str());
+
+  char pumpBuf[14];
+  snprintf(pumpBuf, sizeof(pumpBuf), " Pump: %s",
+           poolPumpNode.getSwitch() ? "on " : "off");
+
+  const char *exitItem = "  Exit menu";
+
+  // ── Render items (12 px line height) ──────────────────────────────────
+  static constexpr uint8_t Y0 = 14;
+  static constexpr uint8_t LH = 12;
+
+  // Item 1: Mode
+  if (menuSelection_ == MenuItem::MODE) {
+    dspInvertedText(4, Y0, modeBuf);
+  } else {
+    dspCursor(4, Y0);
+    display.print(modeBuf);
+  }
+
+  // Item 2: Pump
+  if (menuSelection_ == MenuItem::PUMP) {
+    dspInvertedText(4, Y0 + LH, pumpBuf);
+  } else {
+    dspCursor(4, Y0 + LH);
+    display.print(pumpBuf);
+  }
+
+  // Item 3: Exit
+  if (menuSelection_ == MenuItem::EXIT) {
+    dspInvertedText(4, Y0 + 2 * LH, exitItem);
+  } else {
+    dspCursor(4, Y0 + 2 * LH);
+    display.print(exitItem);
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -703,7 +829,15 @@ void NorviOledDisplay::drawWiFiSetupPage() {
 void NorviOledDisplay::drawSensorSetupPage() {
   display.setTextSize(1);
   dspCursor(0, 0);
-  display.print(F(" Sensor Setup"));
+  display.print(F(" Setup"));
+  // Step indicator [1/2] or [2/2] when wizard is active
+  if (setupStep_ != SetupStep::IDLE) {
+    char stepBuf[8];
+    uint8_t stepNum = (setupStep_ == SetupStep::SELECT_SENSOR) ? 1 : 2;
+    snprintf(stepBuf, sizeof(stepBuf), " [%d/2]", stepNum);
+    dspCursor(60, 0);
+    display.print(stepBuf);
+  }
   dspHLine(0, 9, 128, SSD1306_WHITE);
 
   const uint8_t devCount = solarTemperatureNode.getDeviceCount();
@@ -970,6 +1104,15 @@ void NorviOledDisplay::getMapping(uint8_t solarAddr[8], uint8_t poolAddr[8]) {
 }
 
 void NorviOledDisplay::setupSelectPrevious() {
+  // ── Cancel: at first item, go back to IDLE ──────────────────────────
+  if (setupStep_ == SetupStep::SELECT_SENSOR && setupSelectedDev_ == 0) {
+    setupStep_ = SetupStep::IDLE;
+    setupSelectedDev_ = 0;
+    forceRedraw_ = true;
+    Serial.println("→ Sensor setup cancelled, back to IDLE");
+    return;
+  }
+
   uint8_t devCount = solarTemperatureNode.getDeviceCount();
   if (devCount > 2) {
     devCount = 2;

--- a/src/NorviOledDisplay.hpp
+++ b/src/NorviOledDisplay.hpp
@@ -60,6 +60,15 @@ public:
     SELECT_ROLE,    ///< S1/S2 picks Solar or Pool, S3 assigns
   };
 
+  // ── Action menu items (MAIN page via S3) ────────────────────────────
+
+  /** @brief Items in the MAIN-page action menu. */
+  enum class MenuItem : std::uint8_t {
+    MODE = 0,  ///< Cycle operation mode
+    PUMP,      ///< Toggle pump on/off
+    EXIT       ///< Return to MAIN
+  };
+
   // ── Public API ───────────────────────────────────────────────────────
 
   /** @brief Initialize the OLED display + splash screen. */
@@ -80,6 +89,26 @@ public:
 
   /** @brief Confirm / action button (S3). */
   static void confirmAction();
+
+  // ── Action menu (MAIN page) ─────────────────────────────────────────
+
+  /** @brief Check if the action menu is active. */
+  static bool isMenuActive() { return menuActive_; }
+
+  /** @brief Get the currently selected menu item. */
+  static MenuItem getMenuSelection() { return menuSelection_; }
+
+  /** @brief Enter the action menu (from MAIN page). */
+  static void enterMenu();
+
+  /** @brief Exit the action menu, return to MAIN. */
+  static void exitMenu();
+
+  /** @brief Move menu selection to next item (down). */
+  static void menuNext();
+
+  /** @brief Move menu selection to previous item (up). */
+  static void menuPrevious();
 
   /** @brief Get the currently active page. */
   static Page getCurrentPage() { return currentPage_; }
@@ -152,6 +181,9 @@ private:
   /** @brief Draw WIFI_SETUP — captive portal info + QR. */
   static void drawWiFiSetupPage();
 
+  /** @brief Draw the action menu overlay (MAIN page). */
+  static void drawMenuPage();
+
   /** @brief Draw SENSOR_SETUP — address mapping wizard. */
   static void drawSensorSetupPage();
 
@@ -207,6 +239,10 @@ private:
   static uint8_t setupSolarAddr_[8];
   static uint8_t setupPoolAddr_[8];
   static bool setupRoleIsSolar_;  ///< true = Solar, false = Pool (in SELECT_ROLE)
+
+  // ── Action menu state ──────────────────────────────────────────────
+  static bool menuActive_;          ///< True while action menu is shown
+  static MenuItem menuSelection_;   ///< Currently highlighted menu item
 
   // ── First-boot flow tracking ─────────────────────────────────────────
   static bool firstBootDone_;  ///< True after initial setup flow completed

--- a/src/PoolController.cpp
+++ b/src/PoolController.cpp
@@ -292,57 +292,74 @@ auto PoolControllerContext::setup() -> void {
   NorviOledDisplay::begin();
   NorviButtonHandler::begin();
 
-  // Wire button callbacks (new navigation: S1=UP, S2=DOWN, S3=CONFIRM)
+  // Wire button callbacks (S1=UP, S2=DOWN, S3=ACTION)
   // ── S1 (UP) ───────────────────────────────────────────────────────────
   NorviButtonHandler::onButton1Press([]() {
-    if (NorviOledDisplay::isSelectSensorStep()) {
-      // Sensor selection: move to previous sensor
+    if (NorviOledDisplay::isMenuActive()) {
+      NorviOledDisplay::menuPrevious();
+    } else if (NorviOledDisplay::isSelectSensorStep()) {
       NorviOledDisplay::setupSelectPrevious();
       NorviOledDisplay::requestRedraw();
     } else if (NorviOledDisplay::isSelectRoleStep()) {
-      // Role selection: toggle Solar ↔ Pool
       NorviOledDisplay::setupToggleRole();
       NorviOledDisplay::requestRedraw();
     } else {
-      // Normal mode: previous page
       NorviOledDisplay::previousPage();
     }
   });
   // ── S2 (DOWN) ─────────────────────────────────────────────────────────
   NorviButtonHandler::onButton2Press([]() {
-    if (NorviOledDisplay::isSelectSensorStep()) {
-      // Sensor selection: move to next sensor
+    if (NorviOledDisplay::isMenuActive()) {
+      NorviOledDisplay::menuNext();
+    } else if (NorviOledDisplay::isSelectSensorStep()) {
       NorviOledDisplay::setupSelectNext();
       NorviOledDisplay::requestRedraw();
     } else if (NorviOledDisplay::isSelectRoleStep()) {
-      // Role selection: toggle Solar ↔ Pool
       NorviOledDisplay::setupToggleRole();
       NorviOledDisplay::requestRedraw();
     } else {
-      // Normal mode: next page
       NorviOledDisplay::nextPage();
     }
   });
   // ── S3 (CONFIRM) ──────────────────────────────────────────────────────
   NorviButtonHandler::onButton3Press([]() {
-    if (NorviOledDisplay::getCurrentPage() == NorviOledDisplay::Page::SENSOR_SETUP) {
-      // Sensor setup page: advance the state machine (IDLE→SELECT→ROLE→assign)
-      NorviOledDisplay::confirmAction();
-    } else {
-      // Normal mode: cycle operation mode
-      NorviOledDisplay::requestRedraw();
-      const String &currentMode = operationModeNode.getMode();
-      if (currentMode == "auto") {
-        operationModeNode.setMode("manu");
-      } else if (currentMode == "manu") {
-        operationModeNode.setMode("boost");
-      } else if (currentMode == "boost") {
-        operationModeNode.setMode("timer");
-      } else {
-        operationModeNode.setMode("auto");
+    if (NorviOledDisplay::isMenuActive()) {
+      // Execute selected menu action, then return to MAIN
+      NorviOledDisplay::Page prevPage = NorviOledDisplay::getCurrentPage();
+      switch (NorviOledDisplay::getMenuSelection()) {
+      case NorviOledDisplay::MenuItem::MODE: {
+        // Cycle operation mode
+        const String &currentMode = operationModeNode.getMode();
+        if (currentMode == "auto") {
+          operationModeNode.setMode("manu");
+        } else if (currentMode == "manu") {
+          operationModeNode.setMode("boost");
+        } else if (currentMode == "boost") {
+          operationModeNode.setMode("timer");
+        } else {
+          operationModeNode.setMode("auto");
+        }
+        Serial.printf("→ Mode switched to: %s\n", operationModeNode.getMode().c_str());
+        break;
       }
-      Serial.printf("→ Mode switched to: %s\n", operationModeNode.getMode().c_str());
+      case NorviOledDisplay::MenuItem::PUMP:
+        // Toggle pool pump
+        poolPumpNode.setSwitch(!poolPumpNode.getSwitch());
+        Serial.printf("→ Pump toggled: %s\n", poolPumpNode.getSwitch() ? "ON" : "OFF");
+        break;
+      case NorviOledDisplay::MenuItem::EXIT:
+        // No action — just exit
+        break;
+      }
+      NorviOledDisplay::exitMenu();
+    } else if (NorviOledDisplay::getCurrentPage() == NorviOledDisplay::Page::MAIN) {
+      // MAIN page: open action menu
+      NorviOledDisplay::enterMenu();
+    } else if (NorviOledDisplay::getCurrentPage() == NorviOledDisplay::Page::SENSOR_SETUP) {
+      // Sensor setup: advance the wizard
+      NorviOledDisplay::confirmAction();
     }
+    // Other info pages: S3 intentionally does nothing
   });
   // ── S3 long-press: save sensor mapping & reboot ───────────────────────
   NorviButtonHandler::onButton3LongPress([]() -> bool {


### PR DESCRIPTION
## PR 2/3 — Aktionsmenü + Wizard-Verbesserungen

Zweite Umsetzung des Navigationskonzepts aus PR #146.

### Aktionsmenü (MAIN-Seite via S3)
S3 auf MAIN öffnet ein 3-Item-Menü statt direktem Mode-Cycle:

| Menü | S3-Aktion |
|------|-----------|
| Mode: auto | Cycle auto→manu→boost→timer |
| Pump: on/off | Pool-Pumpe togglen |
| Exit menu | Zurück zu MAIN |

S1/S2 navigieren, S3 bestätigt. 30s Auto-Return bei Inaktivität.

### Wizard-Cancel
S1 drücken wenn  in SELECT_SENSOR →
zurück zu IDLE. Kein Timeout mehr nötig zum Abbrechen.

### Schritt-Indikator
`[1/2]` / `[2/2]` im Wizard-Titel bei aktivem Setup-Schritt.

### Geänderte Dateien
- `NorviOledDisplay.hpp`: MenuItem enum, menu-Methoden, -State
- `NorviOledDisplay.cpp`: drawMenuPage(), menu-Navigation,
  wizard-cancel, step-indicator, auto-return für Menu
- `PoolController.cpp`: S3 dispatch (menu→execute→MAIN,
  MAIN→enterMenu, SENSOR_SETUP→confirm)

### Build
✅ norvi_ae01_r — SUCCESS (Flash: 96,3%)

### Nächster PR
- **PR 3:** Long-Press-Feedback + Auto-Return-Warnung