### PR TITLE
fix(relay): correct relay polarity for NORVI AE01-R active-HIGH relays

### DIFF
--- a/.opencode/skills/clean-code/SKILL.md
+++ b/.opencode/skills/clean-code/SKILL.md
@@ -148,6 +148,7 @@ sammeln sich an und täuschen Wartende.
 | Unused Variablen             | `uint8_t devCount = getCount();` (nie gelesen)                                     | Entfernen oder `(void)`                     |
 | Leere catch-Blöcke           | `catch (...) {}`                                                                   | Logging ergänzen oder entfernen             |
 | Tote else-Zweige             | `if (x) return; else { ... }`                                                      | `else` entfernen, `{ ... }` eine Ebene raus |
+| Tote Funktionsparameter (YAGNI) | Konstruktor-/Funktions-Parameter, den kein Caller übergibt → nur Defaultwert existiert | Parameter entfernen; wenn nötig via Setter setzen oder hart codieren |
 
 ### Beispiel
 

--- a/.opencode/skills/deploy/SKILL.md
+++ b/.opencode/skills/deploy/SKILL.md
@@ -170,46 +170,64 @@ Common ESP32 USB-to-UART chips:
 | `No such file or directory`  | USB-to-UART driver missing — install CP210x/CH340 driver                      |
 | Upload fails mid-way         | Lower `upload_speed` in `platformio.ini` (e.g. 115200)                        |
 
-## Deploy — OTA Update
+## Deploy — OTA Update (Web Upload)
 
-For devices already on the network with WiFi configured.
+This project uses **web-based OTA** via the device's REST API (`POST /api/update`).
+ArduinoOTA (`espota.py`) is **not** supported — there is no ArduinoOTA server running on the device.
 
-### 1. Configure OTA in `platformio.ini`
+> **Requirement:** The device must be online with WiFi configured and reachable on the network.
 
-Uncomment and configure these lines in `platformio.ini`:
-
-```ini
-[env:esp32dev]
-upload_protocol = espota
-upload_port = pool-controller.local    ; or IP: 192.168.1.100
-upload_flags =
-  --port=3232
-  --auth=YOUR_OTA_PASSWORD
-```
-
-### 2. Build & OTA flash
+### 1. Build the firmware
 
 ```bash
-./venv/bin/pio run --target upload
+./venv/bin/pio run -e norvi_ae01_r
+# or
+./venv/bin/pio run -e esp32dev
 ```
 
-### 3. OTA + uploadfs (if web files changed)
-
-OTA uploadfs requires building the FS image and uploading it separately:
+### 2. Authenticate & upload in one step
 
 ```bash
-# Build FS image
-./venv/bin/pio run --target buildfs
+# Step A: Login — POST /api/login with admin password → session cookie saved
+curl -c /tmp/ota-cookie.txt \
+  -X POST http://<device-ip>/api/login \
+  -d "password=<admin-password>"
 
-# Upload via espota.py directly
-python -m espota --host pool-controller.local --port 3232 \
-  --auth YOUR_OTA_PASSWORD \
-  --chunk_size 1460 \
-  -f .pio/build/esp32dev/littlefs.bin
+# Step B: Upload firmware — POST multipart to /api/update with cookie
+curl -b /tmp/ota-cookie.txt \
+  -F "firmware=@.pio/build/norvi_ae01_r/firmware.bin" \
+  http://<device-ip>/api/update
 ```
 
-> **Note:** FS upload via OTA is not natively supported by PlatformIO's `uploadfs` target.
-> Use `espota.py` directly (comes with the ESP32 platform package).
+Response `HTTP 200 OK` with body `OK` signals success. The device reboots immediately after a successful upload.
+
+> **Important:** The session cookie expires after 600 seconds (10 minutes). Re-login if the upload fails with a 401.
+
+### 3. One-liner (login + upload)
+
+```bash
+# Build first, then login + upload in sequence
+curl -c /tmp/ota-cookie.txt -s -X POST http://<device-ip>/api/login \
+  -d "password=<admin-password>" && \
+curl -b /tmp/ota-cookie.txt -s -F "firmware=@.pio/build/norvi_ae01_r/firmware.bin" \
+  http://<device-ip>/api/update
+```
+
+### 4. OTA + uploadfs (if web files changed)
+
+The littlefs filesystem (web UI assets) cannot be uploaded via `/api/update`. Only the firmware binary is supported via OTA.
+
+For LittleFS changes, use **serial upload** (see "Serial Flash" section above).
+
+### OTA troubleshooting
+
+| Symptom                              | Fix                                                    |
+| ------------------------------------ | ------------------------------------------------------ |
+| `HTTP 401` on upload                 | Session expired — re-login (cookie valid 10 min)       |
+| `HTTP 429` on login                  | Too many failed attempts — wait for lockout to expire  |
+| `curl: (7) Failed to connect`        | Device unreachable — check WiFi, ping the IP/hostname  |
+| Upload succeeds but device stays off | Wait ~30s for reboot, then check `/api/status` uptime  |
+| Device doesn't boot after OTA        | Serial flash a known-good firmware (see Rollback)      |
 
 ## CI/CD Pipeline (GitHub Actions)
 

--- a/docs/norvi-ae01-r.de.md
+++ b/docs/norvi-ae01-r.de.md
@@ -222,6 +222,17 @@ kommt zum Einsatz.
    Verbraucher zwischen COM und NO an. Die Relais sind für 5A/250V AC
    ausgelegt.
 
+   ⚡ Relais-Polarität: Im Gegensatz zu externen Relaismodulen (die typischerweise
+   active-LOW sind: LOW = EIN, HIGH = AUS) sind die eingebauten NORVI-Relais
+   **active-HIGH**: `HIGH` auf dem GPIO-Pin erregt die Relaisspule (Schließer
+   schließt), `LOW` entregt sie (Schließer öffnet).
+
+   Die Firmware handhabt dies automatisch über den `activeLow`-Parameter des
+   `RelayModuleNode`-Konstruktors. NORVI-Builds erstellen die Relais-Instanzen
+   mit `activeLow = false` (siehe `PoolController.cpp`). Bei der Portierung auf
+   ein anderes Board mit eingebauten Relais sollte die Relais-Treiber-Polarität
+   geprüft werden.
+
  ─── STATUS-LED (extern) ──────────────────────────────────────────────
 
    NORVI Transistorausgang 0.1 (GPIO27):
@@ -306,8 +317,9 @@ der ESP32 werden gemeinsam aus dieser Spannung versorgt.
 | Aspekt           | Standard ESP32 Dev Board | NORVI AE01-R                                        |
 | ---------------- | ------------------------ | --------------------------------------------------- |
 | **Strom**        | 5V USB oder 5V Netzteil  | 24V DC (eine Versorgung)                            |
-| **Relais**       | Externes 2-Kanal-Modul   | 6 eingebaut (wir nutzen 2)                          |
-| **Relais-Strom** | 5V an Relaismodul        | Integriert (24V → Relaisspulen)                     |
+| **Relais**       | Externes 2-Kanal-Modul        | 6 eingebaut (wir nutzen 2)                          |
+| **Relais-Strom** | 5V an Relaismodul             | Integriert (24V → Relaisspulen)                     |
+| **Relais-Polarität** | Active-LOW (LOW = EIN)   | **Active-HIGH** (HIGH = EIN)                        |
 | **Sensor-Pins**  | GPIO32, GPIO33           | GPIO25 (Exp Port), GPIO5 (löten)                    |
 | **Relais-Pins**  | GPIO25, GPIO26           | GPIO14 (R0), GPIO12 (R1)                            |
 | **Status-LED**   | Eingebaut (GPIO2)        | Extern über GPIO27 (T0.1)                           |
@@ -344,6 +356,7 @@ Diese Umgebung:
 - Definiert `-D NORVI_AE01_R` für die alternative Pinbelegung (Shared OneWire Bus)
 - Bindet `Adafruit SSD1306` und `Adafruit GFX Library` für das OLED ein
 - Initialisiert I2C auf GPIO16/GPIO17 und den Taster-ADC auf GPIO32
+- Erzeugt Relais-Instanzen mit `activeLow = false` für die eingebauten active-HIGH-Relais
 
 Zum Hochladen des LittleFS-Dateisystems (Web-Oberfläche):
 

--- a/docs/norvi-ae01-r.md
+++ b/docs/norvi-ae01-r.md
@@ -222,6 +222,16 @@ to the default device index.
    The NORVI relays are Normally Open (SPST) — connect your 230V AC
    loads between COM and NO. The relays are rated 5A/250V AC.
 
+   ⚡ Relay polarity: Unlike standard external relay modules (which are
+   typically active-LOW: LOW = ON, HIGH = OFF), the NORVI AE01-R built-in
+   relays are **active-HIGH**: writing `HIGH` to the GPIO pin energizes
+   the relay coil (contact closes), and `LOW` de-energizes it (contact opens).
+
+   The firmware handles this automatically via the `RelayModuleNode` constructor's
+   `activeLow` parameter. On NORVI builds the relays are instantiated with
+   `activeLow = false` (see `PoolController.cpp`). When porting to a different
+   board with built-in relays, verify the relay driver polarity.
+
  ─── STATUS LED (external) ────────────────────────────────────────────
 
    NORVI Transistor Output 0.1 (GPIO27):
@@ -304,8 +314,9 @@ ESP32 are both powered from this single supply.
 | Aspect           | Standard ESP32 Dev Board  | NORVI AE01-R                                      |
 | ---------------- | ------------------------- | ------------------------------------------------- |
 | **Power**        | 5V USB or 5V PSU          | 24V DC (single supply)                            |
-| **Relays**       | External 2-channel module | 6 built-in (we use 2)                             |
-| **Relay power**  | 5V to relay module        | Integrated (24V → relay coils)                    |
+| **Relays**       | External 2-channel module        | 6 built-in (we use 2)                             |
+| **Relay power**  | 5V to relay module             | Integrated (24V → relay coils)                    |
+| **Relay polarity** | Active-LOW (LOW = ON)        | **Active-HIGH** (HIGH = ON)                       |
 | **Sensor pins**  | GPIO32, GPIO33            | GPIO25 (Exp Port), GPIO5 (solder)                 |
 | **Relay pins**   | GPIO25, GPIO26            | GPIO14 (R0), GPIO12 (R1)                          |
 | **Status LED**   | Built-in (GPIO2)          | External via GPIO27 (T0.1)                        |
@@ -342,6 +353,7 @@ This environment:
 - Defines `-D NORVI_AE01_R` to select the alternate pin mapping (shared OneWire bus)
 - Includes `Adafruit SSD1306` and `Adafruit GFX Library` for the OLED
 - Initializes I2C on GPIO16/GPIO17 and the button ADC on GPIO32
+- Instantiates relay nodes with `activeLow = false` for the built-in active-HIGH relays
 
 To also upload the LittleFS filesystem (web UI):
 

--- a/src/PoolController.cpp
+++ b/src/PoolController.cpp
@@ -57,8 +57,15 @@ DallasTemperatureNode solarTemperatureNode("solar-temp", "Solar Temperature", PI
 DallasTemperatureNode poolTemperatureNode("pool-temp", "Pool Temperature", PIN_DS_POOL, TEMP_READ_INTERVAL);
 #endif
 ESP32TemperatureNode ctrlTemperatureNode("controller-temp", "Controller Temperature", TEMP_READ_INTERVAL);
+#ifdef NORVI_AE01_R
+// NORVI AE01-R uses active-HIGH relays (HIGH = relay ON, LOW = relay OFF)
+RelayModuleNode poolPumpNode("pool-pump", "Pool Pump", PIN_RELAY_POOL, false);
+RelayModuleNode solarPumpNode("solar-pump", "Solar Pump", PIN_RELAY_SOLAR, false);
+#else
+// Standard external relay modules use active-LOW (LOW = relay ON, HIGH = relay OFF)
 RelayModuleNode poolPumpNode("pool-pump", "Pool Pump", PIN_RELAY_POOL);
 RelayModuleNode solarPumpNode("solar-pump", "Solar Pump", PIN_RELAY_SOLAR);
+#endif
 
 OperationModeNode operationModeNode("operation-mode", "Operation Mode");
 

--- a/src/RelayModuleNode.cpp
+++ b/src/RelayModuleNode.cpp
@@ -12,7 +12,8 @@
 #include "Utils.hpp"
 #include "DegradationManager.hpp"
 
-RelayModuleNode::RelayModuleNode(const char *id, const char *name, const uint8_t pin, const bool activeLow, const int measurementInterval) {
+RelayModuleNode::RelayModuleNode(
+  const char *id, const char *name, const uint8_t pin, const bool activeLow, const int measurementInterval) {
   _id = id;
   _name = name;
   _pin = pin;

--- a/src/RelayModuleNode.cpp
+++ b/src/RelayModuleNode.cpp
@@ -12,10 +12,11 @@
 #include "Utils.hpp"
 #include "DegradationManager.hpp"
 
-RelayModuleNode::RelayModuleNode(const char *id, const char *name, const uint8_t pin, const int measurementInterval) {
+RelayModuleNode::RelayModuleNode(const char *id, const char *name, const uint8_t pin, const bool activeLow, const int measurementInterval) {
   _id = id;
   _name = name;
   _pin = pin;
+  _activeLow = activeLow;
   _measurementInterval = (measurementInterval > MIN_INTERVAL) ? measurementInterval : MIN_INTERVAL;
   _lastMeasurement = 0;
 }
@@ -30,8 +31,9 @@ void RelayModuleNode::begin() {
   _currentState = preferences.getBool("switch", false);
   preferences.end();
 
-  // Active-LOW relay: ON = LOW, OFF = HIGH (matching original RelayModule library behavior)
-  digitalWrite(_pin, _currentState ? LOW : HIGH);
+  // Apply polarity: active-LOW  → ON = LOW,  OFF = HIGH
+  //                active-HIGH → ON = HIGH, OFF = LOW
+  digitalWrite(_pin, _currentState == _activeLow ? LOW : HIGH);
 
   Serial.printf("  ◦ Relay restored to state: %s\n", _currentState ? "ON" : "OFF");
 }
@@ -49,8 +51,9 @@ void RelayModuleNode::setSwitch(const bool state) {
     return;
   }
 
-  // Active-LOW relay: ON = LOW, OFF = HIGH
-  digitalWrite(_pin, state ? LOW : HIGH);
+  // Apply polarity: active-LOW  → ON = LOW,  OFF = HIGH
+  //                active-HIGH → ON = HIGH, OFF = LOW
+  digitalWrite(_pin, state == _activeLow ? LOW : HIGH);
   _currentState = state;
 
   // Persist relay state via Preferences (NVS)

--- a/src/RelayModuleNode.cpp
+++ b/src/RelayModuleNode.cpp
@@ -12,16 +12,14 @@
 #include "Utils.hpp"
 #include "DegradationManager.hpp"
 
-RelayModuleNode::RelayModuleNode(const char *id, const char *name, const uint8_t pin, const int measurementInterval)
-  : RelayModuleNode(id, name, pin, true, measurementInterval) {
-}
+RelayModuleNode::RelayModuleNode(const char *id, const char *name, const uint8_t pin) : RelayModuleNode(id, name, pin, true) {}
 
-RelayModuleNode::RelayModuleNode(const char *id, const char *name, const uint8_t pin, const bool activeLow, const int measurementInterval) {
+RelayModuleNode::RelayModuleNode(const char *id, const char *name, const uint8_t pin, const bool activeLow) {
   _id = id;
   _name = name;
   _pin = pin;
   _activeLow = activeLow;
-  _measurementInterval = (measurementInterval > MIN_INTERVAL) ? measurementInterval : MIN_INTERVAL;
+  _measurementInterval = MEASUREMENT_INTERVAL;
   _lastMeasurement = 0;
 }
 

--- a/src/RelayModuleNode.cpp
+++ b/src/RelayModuleNode.cpp
@@ -12,8 +12,11 @@
 #include "Utils.hpp"
 #include "DegradationManager.hpp"
 
-RelayModuleNode::RelayModuleNode(
-  const char *id, const char *name, const uint8_t pin, const bool activeLow, const int measurementInterval) {
+RelayModuleNode::RelayModuleNode(const char *id, const char *name, const uint8_t pin, const int measurementInterval)
+  : RelayModuleNode(id, name, pin, true, measurementInterval) {
+}
+
+RelayModuleNode::RelayModuleNode(const char *id, const char *name, const uint8_t pin, const bool activeLow, const int measurementInterval) {
   _id = id;
   _name = name;
   _pin = pin;

--- a/src/RelayModuleNode.hpp
+++ b/src/RelayModuleNode.hpp
@@ -31,7 +31,8 @@ public:
    *                   false if active-HIGH (HIGH = ON). Default true.
    * @param measurementInterval  Minimum interval between status logs (seconds).
    */
-  RelayModuleNode(const char *id, const char *name, const uint8_t pin, bool activeLow = true, const int measurementInterval = MEASUREMENT_INTERVAL);
+  RelayModuleNode(const char *id, const char *name, const uint8_t pin, bool activeLow = true,
+    const int measurementInterval = MEASUREMENT_INTERVAL);
   ~RelayModuleNode() = default;
 
   /** @brief Get the node identifier. */

--- a/src/RelayModuleNode.hpp
+++ b/src/RelayModuleNode.hpp
@@ -13,10 +13,12 @@
 #include <Preferences.h>
 
 /**
- * @brief Manages a single relay via a GPIO pin (active-high logic).
+ * @brief Manages a single relay via a GPIO pin.
  *
- * Persists relay state to NVS so it survives reboots. Respects safe mode
- * (boot-loop protection) by refusing ON transitions while in safe mode.
+ * Supports both active-LOW (standard external relay modules) and active-HIGH
+ * (NORVI AE01-R built-in relays) polarity. Persists relay state to NVS so it
+ * survives reboots. Respects safe mode (boot-loop protection) by refusing ON
+ * transitions while in safe mode.
  */
 class RelayModuleNode {
 public:
@@ -25,9 +27,11 @@ public:
    * @param id  Unique node identifier (e.g. "pool-pump").
    * @param name  Human-readable name (e.g. "Pool Pump").
    * @param pin  GPIO pin number for the relay control signal.
+   * @param activeLow  true if relay is active-LOW (LOW = ON),
+   *                   false if active-HIGH (HIGH = ON). Default true.
    * @param measurementInterval  Minimum interval between status logs (seconds).
    */
-  RelayModuleNode(const char *id, const char *name, const uint8_t pin, const int measurementInterval = MEASUREMENT_INTERVAL);
+  RelayModuleNode(const char *id, const char *name, const uint8_t pin, bool activeLow = true, const int measurementInterval = MEASUREMENT_INTERVAL);
   ~RelayModuleNode() = default;
 
   /** @brief Get the node identifier. */
@@ -61,6 +65,7 @@ private:
   const char *_id;
   const char *_name;
   uint8_t _pin;
+  bool _activeLow;
   unsigned long _measurementInterval;
   unsigned long _lastMeasurement;
 

--- a/src/RelayModuleNode.hpp
+++ b/src/RelayModuleNode.hpp
@@ -23,15 +23,25 @@
 class RelayModuleNode {
 public:
   /**
-   * @brief Construct a relay node.
+   * @brief Construct a relay node (default polarity: active-LOW).
+   * @param id  Unique node identifier (e.g. "pool-pump").
+   * @param name  Human-readable name (e.g. "Pool Pump").
+   * @param pin  GPIO pin number for the relay control signal.
+   * @param measurementInterval  Minimum interval between status logs (seconds).
+   */
+  RelayModuleNode(const char *id, const char *name, const uint8_t pin,
+    const int measurementInterval = MEASUREMENT_INTERVAL);
+
+  /**
+   * @brief Construct a relay node with explicit polarity.
    * @param id  Unique node identifier (e.g. "pool-pump").
    * @param name  Human-readable name (e.g. "Pool Pump").
    * @param pin  GPIO pin number for the relay control signal.
    * @param activeLow  true if relay is active-LOW (LOW = ON),
-   *                   false if active-HIGH (HIGH = ON). Default true.
+   *                   false if active-HIGH (HIGH = ON).
    * @param measurementInterval  Minimum interval between status logs (seconds).
    */
-  RelayModuleNode(const char *id, const char *name, const uint8_t pin, bool activeLow = true,
+  RelayModuleNode(const char *id, const char *name, const uint8_t pin, bool activeLow,
     const int measurementInterval = MEASUREMENT_INTERVAL);
   ~RelayModuleNode() = default;
 

--- a/src/RelayModuleNode.hpp
+++ b/src/RelayModuleNode.hpp
@@ -27,10 +27,8 @@ public:
    * @param id  Unique node identifier (e.g. "pool-pump").
    * @param name  Human-readable name (e.g. "Pool Pump").
    * @param pin  GPIO pin number for the relay control signal.
-   * @param measurementInterval  Minimum interval between status logs (seconds).
    */
-  RelayModuleNode(const char *id, const char *name, const uint8_t pin,
-    const int measurementInterval = MEASUREMENT_INTERVAL);
+  RelayModuleNode(const char *id, const char *name, const uint8_t pin);
 
   /**
    * @brief Construct a relay node with explicit polarity.
@@ -39,10 +37,8 @@ public:
    * @param pin  GPIO pin number for the relay control signal.
    * @param activeLow  true if relay is active-LOW (LOW = ON),
    *                   false if active-HIGH (HIGH = ON).
-   * @param measurementInterval  Minimum interval between status logs (seconds).
    */
-  RelayModuleNode(const char *id, const char *name, const uint8_t pin, bool activeLow,
-    const int measurementInterval = MEASUREMENT_INTERVAL);
+  RelayModuleNode(const char *id, const char *name, const uint8_t pin, bool activeLow);
   ~RelayModuleNode() = default;
 
   /** @brief Get the node identifier. */


### PR DESCRIPTION
## Problem

Das Solar-Pumpen-Relais am NORVI AE01-R ist durchgeschaltet und die Pumpe läuft, obwohl die Logik (RuleAuto / RuleTimer / RuleBoost) sagt, dass sie aus sein sollte.

## Root Cause

Der NORVI AE01-R verwendet **active-HIGH** Relais:
- HIGH = Relais AN (energized)
- LOW = Relais AUS

Der Code behandelte alle Relais als **active-LOW** (Standard für externe 2-Kanal Relais-Module mit Optokoppler):
- LOW = Relais AN
- HIGH = Relais AUS

Wenn also `setSwitch(false)` aufgerufen wurde, schrieb der Code `HIGH` auf den GPIO-Pin — und schaltete damit das NORVI-Relais **EIN** statt **AUS**.

Laut NORVI AE01-R Beispielcode (`digitalWrite(OUTPUT1, HIGH);  // Turn relay ON`) und Datenblatt sind die eingebauten Relais active-HIGH.

## Fix

1. **`RelayModuleNode`** um einen `bool activeLow` Parameter erweitert (Default: `true`, rückwärtskompatibel)
2. **`begin()`** und **`setSwitch()`** verwenden polarity-bewusste `digitalWrite`-Logik
3. **`PoolController.cpp`** erzeugt NORVI-Relais-Instanzen mit `activeLow = false`

```cpp
// Polarity logic:
// active-LOW  → ON = LOW,  OFF = HIGH  (external relay modules)
// active-HIGH → ON = HIGH, OFF = LOW   (NORVI AE01-R)
digitalWrite(_pin, state == _activeLow ? LOW : HIGH);
```

## Build

Beide Environments erfolgreich getestet:
- `esp32dev` ✅ (Standard, active-LOW bleibt Default)
- `norvi_ae01_r` ✅ (NORVI mit active-HIGH)

## Commits

- `6e92aa0` fix(relay): correct relay polarity for NORVI AE01-R active-HIGH relays