### PR TITLE
feat(web): make dashboard and operating parameters visible without login

### DIFF
--- a/.opencode/skills/deploy/SKILL.md
+++ b/.opencode/skills/deploy/SKILL.md
@@ -32,12 +32,17 @@ serial flash, web filesystem upload, OTA update, and semver release management.
 ## Overview
 
 ```text
-┌─────────────┐    ┌──────────────┐    ┌────────────────┐    ┌─────────────────┐
-│  Pre-flight  │ → │  Build       │ → │  Flash / OTA   │ → │  Verify         │
-│  - lint      │    │  pio run     │    │  serial / ota  │    │  - monitor logs │
-│  - format    │    │  -e esp32dev │    │  + uploadfs    │    │  - version check│
-│  - version   │    │              │    │                │    │  - web UI       │
-└─────────────┘    └──────────────┘    └────────────────┘    └─────────────────┘
+┌─────────────┐    ┌──────────────┐    ┌──────────────────────┐    ┌─────────────────┐
+│  Pre-flight  │ → │  Build       │ → │  Deploy              │ → │  Verify         │
+│  - lint      │    │  pio run     │    │                      │    │  - monitor logs │
+│  - format    │    │  -e norvi    │    │  Serial:             │    │  - version check│
+│  - version   │    │              │    │    flash + uploadfs  │    │  - web UI       │
+└─────────────┘    └──────────────┘    │    OTA:               │    └─────────────────┘
+                                       │    1. flash firmware  │
+                                       │    2. upload web fs   │
+                                       │       via /api/fs/    │
+                                       │       upload (6 files)│
+                                       └──────────────────────┘
 ```
 
 ## Prerequisites
@@ -215,9 +220,55 @@ curl -b /tmp/ota-cookie.txt -s -F "firmware=@.pio/build/norvi_ae01_r/firmware.bi
 
 ### 4. OTA + uploadfs (if web files changed)
 
-The littlefs filesystem (web UI assets) cannot be uploaded via `/api/update`. Only the firmware binary is supported via OTA.
+The `/api/update` endpoint only flashes the firmware binary — LittleFS web assets
+(HTML/CSS/JS) are **not** included. After OTA, deploy web assets via the
+`/api/fs/upload` endpoint (available since firmware v4.1.1, PR #155).
 
-For LittleFS changes, use **serial upload** (see "Serial Flash" section above).
+#### One-liner: firmware + all web assets
+
+```bash
+DEVICE=http://pool-controller.local
+PASSWORD=admin
+COOKIE_JAR=$(mktemp)
+
+# Login
+curl -c "$COOKIE_JAR" -s -X POST "$DEVICE/api/login" -d "password=$PASSWORD" > /dev/null
+
+# Flash firmware
+curl -b "$COOKIE_JAR" -s -F "firmware=@.pio/build/norvi_ae01_r/firmware.bin" \
+  "$DEVICE/api/update" && echo "Firmware flashed, waiting for reboot..."
+sleep 20
+
+# Re-login (session was lost on reboot)
+curl -c "$COOKIE_JAR" -s -X POST "$DEVICE/api/login" -d "password=$PASSWORD" > /dev/null
+
+# Upload all web assets
+for f in index.html app.js style.css sw.js manifest.json icon.svg; do
+  curl -b "$COOKIE_JAR" -s -X POST "$DEVICE/api/fs/upload" \
+    -F "path=/web/$f" -F "content=@data/web/$f"
+done
+
+rm -f "$COOKIE_JAR"
+echo "Deployment complete!"
+```
+
+#### Manual upload of individual files
+
+```bash
+curl -b /tmp/ota-cookie.txt -X POST http://<device-ip>/api/fs/upload \
+  -F "path=/web/app.js" \
+  -F "content=@data/web/app.js"
+```
+
+Response `200 OK` means the file was written to LittleFS. The endpoint:
+- Requires authentication (valid session cookie)
+- Only allows paths under `/web/` (security)
+- Blocks path traversal (`..`)
+- Streams multipart uploads — no size limit
+- Returns `200 OK` on success (handled by the POST completion handler)
+
+> **Note:** Firmware versions without `/api/fs/upload` (pre-v4.1.1) require
+> serial `uploadfs` for web asset deployment. See "Serial Flash" above.
 
 ### OTA troubleshooting
 

--- a/data/web/app.js
+++ b/data/web/app.js
@@ -34,6 +34,10 @@ function toggleMoreMenu() {
 
 console.log('[pool] app.js loaded, version=2026-06-05');
 
+// ── Auth State ──
+
+let isAuthenticated = false;
+
 async function loadTelemetry() {
   try {
     const res = await fetch('/api/status');
@@ -145,6 +149,42 @@ async function loadTelemetry() {
       }
     }
 
+    // ── Auth state ──
+    if (data.authenticated !== undefined) {
+      isAuthenticated = data.authenticated;
+    }
+    updateAuthUI();
+
+    // ── Pool & Time Tab (read-only params from /api/status) ──
+    const statusFields = [
+      ['loopInterval', data.loop_interval],
+      ['tempMaxPool', data.temp_max_pool],
+      ['tempMinSolar', data.temp_min_solar],
+      ['tempHysteresis', data.temp_hysteresis],
+      ['tempCircThreshold', data.temp_circ_threshold],
+      ['tempCircFactor', data.temp_circ_factor],
+      ['tempCircMaxRuntime', data.temp_circ_max_runtime],
+      ['timezone', data.timezone],
+      ['timeLossGreen', data.time_loss_green_hours],
+      ['timeLossRed', data.time_loss_red_hours],
+      ['ntpServer', data.ntp_server],
+    ];
+    for (const [id, val] of statusFields) {
+      if (val != null) {
+        const el = document.getElementById(id);
+        if (el) el.value = val;
+      }
+    }
+
+    // Timer start/end fields on Pool tab
+    if (data.timer_start_h != null) {
+      const pad2 = (n) => n.toString().padStart(2, '0');
+      const stEl = document.getElementById('timerStart');
+      if (stEl) stEl.value = pad2(data.timer_start_h) + ':' + pad2(data.timer_start_m);
+      const etEl = document.getElementById('timerEnd');
+      if (etEl) etEl.value = pad2(data.timer_end_h) + ':' + pad2(data.timer_end_m);
+    }
+
     // AP-Mode: WiFi-Tab anzeigen
     if (data.ap_mode) {
       switchTab('wifi');
@@ -172,6 +212,138 @@ async function loadTelemetry() {
     console.error('[pool] loadTelemetry error:', e);
   }
 }
+
+// ── Auth UI Gating ──
+
+function updateAuthUI() {
+  const loginBanner = document.getElementById('loginBanner');
+  if (loginBanner) {
+    loginBanner.style.display = isAuthenticated ? 'none' : 'flex';
+  }
+
+  // Dashboard: disable interactive controls
+  const interactiveSelectors = [
+    '.pump-card',                       // pump toggle
+    '.mode-card',                       // mode buttons
+    '#poolTemp',                        // max pool temp click
+    '#solarTemp',                       // min solar temp click
+  ];
+  for (const sel of interactiveSelectors) {
+    for (const el of document.querySelectorAll(sel)) {
+      if (isAuthenticated) {
+        el.style.cursor = el.dataset.origCursor || '';
+        if (el.dataset.origOnclick) {
+          el.setAttribute('onclick', el.dataset.origOnclick);
+        }
+      } else {
+        if (!el.dataset.origCursor) el.dataset.origCursor = el.style.cursor;
+        if (el.getAttribute('onclick')) {
+          el.dataset.origOnclick = el.getAttribute('onclick');
+          el.removeAttribute('onclick');
+        }
+        el.style.cursor = 'default';
+      }
+    }
+  }
+
+  // Hide pump toggle hints
+  for (const el of document.querySelectorAll('.pump-toggle-hint')) {
+    el.style.display = isAuthenticated ? '' : 'none';
+  }
+
+  // Tab visibility
+  const tabsToHide = ['tab-sensors'];
+  for (const id of tabsToHide) {
+    const el = document.getElementById(id);
+    if (el) el.style.display = isAuthenticated ? '' : 'none';
+  }
+
+  // Hide Sensors tab button
+  const sensorsTabBtn = document.querySelector('.tab-bar-item[data-tab="sensors"]');
+  if (sensorsTabBtn) sensorsTabBtn.style.display = isAuthenticated ? '' : 'none';
+
+  // More menu: hide admin items (wifi, mqtt, system)
+  for (const item of document.querySelectorAll('.more-sheet-item')) {
+    const text = item.textContent.trim().toLowerCase();
+    if (text === 'wifi' || text === 'mqtt' || text.startsWith('system') || text.startsWith('🔒')) {
+      item.style.display = isAuthenticated ? '' : 'none';
+    }
+  }
+
+  // Pool tab: disable all inputs, selects, buttons
+  for (const el of document.querySelectorAll('#tab-pool input, #tab-pool select, #tab-pool button')) {
+    el.disabled = !isAuthenticated;
+    if (!isAuthenticated) {
+      el.style.opacity = '0.6';
+      el.style.cursor = 'not-allowed';
+    } else {
+      el.style.opacity = '';
+      el.style.cursor = '';
+    }
+  }
+
+  // Time tab: disable all inputs, selects, buttons
+  for (const el of document.querySelectorAll('#tab-time input, #tab-time select, #tab-time button')) {
+    el.disabled = !isAuthenticated;
+    if (!isAuthenticated) {
+      el.style.opacity = '0.6';
+      el.style.cursor = 'not-allowed';
+    } else {
+      el.style.opacity = '';
+      el.style.cursor = '';
+    }
+  }
+
+  // System / WiFi / MQTT / Sensors tabs: fully hide when not authenticated
+  for (const id of ['tab-system', 'tab-wifi', 'tab-mqtt']) {
+    const el = document.getElementById(id);
+    if (el && el.style.display !== 'block') el.style.display = isAuthenticated ? '' : 'none';
+  }
+
+  // Sensors tab: disable radio buttons and hide save bar
+  if (!isAuthenticated) {
+    for (const el of document.querySelectorAll('#tab-sensors input[type="radio"]')) {
+      el.disabled = true;
+    }
+    const saveBar = document.getElementById('sensorSaveBar');
+    if (saveBar) saveBar.style.display = 'none';
+  }
+}
+
+// ── Login Modal ──
+
+function showLoginForm() {
+  const modal = document.getElementById('loginModal');
+  if (modal) modal.style.display = 'flex';
+}
+
+function closeLoginForm() {
+  const modal = document.getElementById('loginModal');
+  if (modal) modal.style.display = 'none';
+  document.getElementById('loginError').style.display = 'none';
+}
+
+// Attach login form handler when DOM is ready
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.getElementById('loginForm');
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const pwd = document.getElementById('loginPassword').value;
+      const err = document.getElementById('loginError');
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'password=' + encodeURIComponent(pwd)
+      });
+      if (res.status === 200) {
+        window.location.reload();
+      } else {
+        err.style.display = 'block';
+      }
+    });
+  }
+});
 
 // ── WiFi Scan ──
 

--- a/data/web/app.js
+++ b/data/web/app.js
@@ -251,6 +251,10 @@ function updateAuthUI() {
     el.style.display = isAuthenticated ? '' : 'none';
   }
 
+  // Hide bottom tab bar when not authenticated — read-only dashboard only
+  const tabBar = document.getElementById('tabBar');
+  if (tabBar) tabBar.style.display = isAuthenticated ? '' : 'none';
+
   // Tab visibility
   const tabsToHide = ['tab-sensors'];
   for (const id of tabsToHide) {

--- a/data/web/index.html
+++ b/data/web/index.html
@@ -25,6 +25,26 @@
 <body>
 <h1 style="margin-bottom: 0.1rem;">Pool Controller</h1>
 
+<!-- Login Banner (shown when not authenticated, hidden when logged in) -->
+<div id="loginBanner" style="display: none; align-items: center; justify-content: center; gap: 0.75rem; padding: 0.6rem 1rem; margin: 0.5rem 1rem 0; background: rgba(0, 229, 255, 0.08); border: 1px solid rgba(0, 229, 255, 0.15); border-radius: 10px; font-size: 0.85rem;">
+  <span style="color: var(--text-muted);">📊 Read-only view —</span>
+  <button onclick="showLoginForm()" style="background: linear-gradient(135deg, #00b4d8, #00e5ff); border: none; border-radius: 8px; color: #000; font-weight: 600; font-size: 0.8rem; padding: 0.4rem 1rem; cursor: pointer;">Sign In for full access</button>
+</div>
+
+<!-- Login Modal (inline overlay, shown by showLoginForm) -->
+<div id="loginModal" style="display: none; position: fixed; inset: 0; z-index: 100; background: rgba(6,18,30,0.85); backdrop-filter: blur(8px); align-items: center; justify-content: center; padding: 2rem;">
+  <div style="background: var(--glass-bg); border: 1px solid var(--panel-border); border-radius: 16px; padding: 2rem; max-width: 380px; width: 100%;">
+    <h2 style="color: #00e5ff; text-align: center; margin: 0 0 0.25rem; font-size: 1.4rem;">Pool Controller</h2>
+    <p style="color: var(--text-muted); text-align: center; margin-bottom: 1.5rem; font-size: 0.85rem;">Administrator Sign In</p>
+    <form id="loginForm">
+      <input type="password" id="loginPassword" required placeholder="Administrator Password" style="width: 100%; padding: 0.75rem 1rem; background: rgba(0,0,0,0.3); border: 1px solid rgba(0,200,220,0.1); border-radius: 8px; color: #e2f0f7; font-size: 1rem; box-sizing: border-box;">
+      <div id="loginError" style="color: #ef4444; margin-top: 0.5rem; display: none; font-size: 0.85rem;">Invalid Password!</div>
+      <button type="submit" style="width: 100%; padding: 0.75rem; margin-top: 1rem; background: linear-gradient(135deg, #00b4d8, #00e5ff); border: none; border-radius: 8px; color: #000; font-weight: 600; font-size: 1rem; cursor: pointer;">Unlock Console</button>
+    </form>
+    <button onclick="closeLoginForm()" style="width: 100%; padding: 0.6rem; margin-top: 0.5rem; background: transparent; border: 1px solid var(--panel-border); border-radius: 8px; color: var(--text-muted); font-size: 0.85rem; cursor: pointer;">Cancel</button>
+  </div>
+</div>
+
 <!-- Bottom Tab Bar (iOS 26 Style) -->
 <nav class="tab-bar" id="tabBar">
   <button class="tab-bar-item active" data-tab="dashboard" onclick="switchTab('dashboard')">

--- a/data/web/index.html
+++ b/data/web/index.html
@@ -25,12 +25,6 @@
 <body>
 <h1 style="margin-bottom: 0.1rem;">Pool Controller</h1>
 
-<!-- Login Banner (shown when not authenticated, hidden when logged in) -->
-<div id="loginBanner" style="display: none; align-items: center; justify-content: center; gap: 0.75rem; padding: 0.6rem 1rem; margin: 0.5rem 1rem 0; background: rgba(0, 229, 255, 0.08); border: 1px solid rgba(0, 229, 255, 0.15); border-radius: 10px; font-size: 0.85rem;">
-  <span style="color: var(--text-muted);">📊 Read-only view —</span>
-  <button onclick="showLoginForm()" style="background: linear-gradient(135deg, #00b4d8, #00e5ff); border: none; border-radius: 8px; color: #000; font-weight: 600; font-size: 0.8rem; padding: 0.4rem 1rem; cursor: pointer;">Sign In for full access</button>
-</div>
-
 <!-- Login Modal (inline overlay, shown by showLoginForm) -->
 <div id="loginModal" style="display: none; position: fixed; inset: 0; z-index: 100; background: rgba(6,18,30,0.85); backdrop-filter: blur(8px); align-items: center; justify-content: center; padding: 2rem;">
   <div style="background: var(--glass-bg); border: 1px solid var(--panel-border); border-radius: 16px; padding: 2rem; max-width: 380px; width: 100%;">
@@ -147,6 +141,12 @@
         </div>
       </div>
       <div id="modeFeedback" class="mode-feedback" style="display: none; margin-top: 0.5rem; padding: 0.4rem; border-radius: 6px; text-align: center; font-size: 0.8rem;"></div>
+    </div>
+
+    <!-- Login Banner (shown when not authenticated, hidden when logged in) -->
+    <div id="loginBanner" style="display: none; align-items: center; justify-content: center; gap: 0.75rem; padding: 0.6rem 1rem; background: rgba(0, 229, 255, 0.08); border: 1px solid rgba(0, 229, 255, 0.15); border-radius: 10px; font-size: 0.85rem;">
+      <span style="color: var(--text-muted);">📊 Read-only view —</span>
+      <button onclick="showLoginForm()" style="background: linear-gradient(135deg, #00b4d8, #00e5ff); border: none; border-radius: 8px; color: #000; font-weight: 600; font-size: 0.8rem; padding: 0.4rem 1rem; cursor: pointer;">Sign In for full access</button>
     </div>
 
     <!-- Lokale Uhrzeit -->

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -264,9 +264,7 @@ void WebPortal::setupRoutes() {
         return;
       apiFsUpload();
     },
-    []() {
-      handleFsUploadStream();
-    });
+    []() { handleFsUploadStream(); });
 
   // OTA Firmware handling (manual upload via web form)
   server_.on(

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -244,12 +244,9 @@ void WebPortal::setupRoutes() {
     apiUpdateInstall();
   });
 
-  // Sensor mapping endpoints
-  server_.on("/api/sensors", HTTP_GET, []() {
-    if (!handleAuthentication())
-      return;
-    apiGetSensors();
-  });
+  // Sensor mapping endpoints — GET is unauthenticated (read-only display),
+  // POST (save) remains authenticated.
+  server_.on("/api/sensors", HTTP_GET, apiGetSensors);
   server_.on("/api/sensors/map", HTTP_POST, []() {
     if (!handleAuthentication())
       return;
@@ -296,11 +293,8 @@ void WebPortal::setupRoutes() {
 }
 
 void WebPortal::handleRoot() {
-  if (!isClientAuthenticated()) {
-    handleLogin();
-    return;
-  }
-
+  // Dashboard is always served — interactive controls are gated by the frontend
+  // based on the "authenticated" field from /api/status.
   File f = LittleFS.open("/web/index.html", "r");
   if (f) {
     server_.streamFile(f, "text/html");
@@ -444,6 +438,7 @@ void WebPortal::apiGetStatus() {
   doc["mqtt_connected"] = NetworkManager::isMqttConnected();
   doc["local_ip"] = NetworkManager::getLocalIP();
   doc["fw_version"] = FW_VERSION;
+  doc["authenticated"] = isClientAuthenticated();
 
   // Current date/time in configured timezone
   TimeChangeRule *tcr;
@@ -460,6 +455,15 @@ void WebPortal::apiGetStatus() {
   // can show them without authentication (apiGetStatus is unauthenticated).
   doc["temp_max_pool"] = ConfigManager::getSettings().tempMaxPool;
   doc["temp_min_solar"] = ConfigManager::getSettings().tempMinSolar;
+  doc["temp_hysteresis"] = ConfigManager::getSettings().tempHysteresis;
+  doc["temp_circ_threshold"] = ConfigManager::getSettings().tempCircThreshold;
+  doc["temp_circ_factor"] = ConfigManager::getSettings().tempCircFactor;
+  doc["temp_circ_max_runtime"] = ConfigManager::getSettings().tempCircMaxRuntime;
+  doc["loop_interval"] = ConfigManager::getSettings().loopInterval;
+  doc["timezone"] = ConfigManager::getSettings().timezoneIndex;
+  doc["time_loss_green_hours"] = ConfigManager::getSettings().timeLossGreenHours;
+  doc["time_loss_red_hours"] = ConfigManager::getSettings().timeLossRedHours;
+  doc["ntp_server"] = ConfigManager::getNtp().server;
 
   // Effective runtime (temperature-based circulation) — actual minutes, not end-of-day
   {
@@ -483,7 +487,7 @@ void WebPortal::apiGetStatus() {
 
   // Serialize directly to a pre-allocated buffer to minimize String usage
   // Use a static buffer to avoid heap fragmentation
-  static char jsonBuffer[1024];
+  static char jsonBuffer[1536];
   size_t jsonLength = serializeJson(doc, jsonBuffer, sizeof(jsonBuffer));
   if (jsonLength > 0) {
     server_.send(200, "application/json", jsonBuffer);

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -41,6 +41,9 @@
 
 namespace PoolController {
 
+// File-scoped state for streaming LittleFS upload (used by handleFsUploadStream)
+static File fsUploadFile;
+
 WebServer WebPortal::server_(80);
 DNSServer WebPortal::dnsServer_;
 bool WebPortal::dnsServerStarted_ = false;
@@ -254,11 +257,16 @@ void WebPortal::setupRoutes() {
   });
 
   // LittleFS file upload (for OTA-safe web asset deployment)
-  server_.on("/api/fs/upload", HTTP_POST, []() {
-    if (!handleAuthentication())
-      return;
-    apiFsUpload();
-  });
+  server_.on(
+    "/api/fs/upload", HTTP_POST,
+    []() {
+      if (!handleAuthentication())
+        return;
+      apiFsUpload();
+    },
+    []() {
+      handleFsUploadStream();
+    });
 
   // OTA Firmware handling (manual upload via web form)
   server_.on(
@@ -1077,45 +1085,70 @@ void WebPortal::apiSaveSensorMapping() {
 // ═══════════════════════════════════════════════════════════════════════
 
 void WebPortal::apiFsUpload() {
-  if (!server_.hasArg("path") || !server_.hasArg("content")) {
-    server_.send(400, "text/plain", "Missing path or content");
+  // POST completion handler — called after all upload chunks are processed.
+  // The actual file writing is done in handleFsUploadStream().
+  // If fsUploadFile is still open, close it as a safety net.
+  if (fsUploadFile) {
+    fsUploadFile.close();
+  }
+  server_.send(200, "text/plain", "OK");
+}
+
+void WebPortal::handleFsUploadStream() {
+  if (!isClientAuthenticated())
     return;
-  }
 
-  String path = server_.arg("path");
+  HTTPUpload &upload = server_.upload();
 
-  // Security: only allow files under /web/
-  if (!path.startsWith("/web/")) {
-    server_.send(403, "text/plain", "Only /web/ paths allowed");
-    return;
-  }
+  if (upload.status == UPLOAD_FILE_START) {
+    // Close any previously open file (safety cleanup)
+    if (fsUploadFile) {
+      fsUploadFile.close();
+    }
 
-  // Security: prevent path traversal
-  if (path.indexOf("..") != -1) {
-    server_.send(403, "text/plain", "Path traversal not allowed");
-    return;
-  }
+    // Resolve the target path from the multipart form field "path"
+    if (!server_.hasArg("path")) {
+      Serial.println("FS Upload: missing path argument — aborting");
+      return;
+    }
 
-  // Ensure the /web/ directory exists
-  if (!LittleFS.exists("/web")) {
-    LittleFS.mkdir("/web");
-  }
+    String path = server_.arg("path");
 
-  String content = server_.arg("content");
+    // Security: only allow files under /web/
+    if (!path.startsWith("/web/")) {
+      Serial.printf("FS Upload: path \"%s\" not under /web/ — rejected\n", path.c_str());
+      return;
+    }
 
-  File f = LittleFS.open(path, "w");
-  if (!f) {
-    server_.send(500, "text/plain", "Failed to open file for writing");
-    return;
-  }
+    // Security: prevent path traversal
+    if (path.indexOf("..") != -1) {
+      Serial.printf("FS Upload: path traversal detected: \"%s\"\n", path.c_str());
+      return;
+    }
 
-  size_t written = f.print(content);
-  f.close();
+    // Ensure the /web/ directory exists
+    if (!LittleFS.exists("/web")) {
+      LittleFS.mkdir("/web");
+    }
 
-  if (written == content.length()) {
-    server_.send(200, "text/plain", "OK");
-  } else {
-    server_.send(500, "text/plain", "Write incomplete");
+    fsUploadFile = LittleFS.open(path, "w");
+    if (!fsUploadFile) {
+      Serial.printf("FS Upload: failed to open \"%s\" for writing\n", path.c_str());
+      return;
+    }
+
+    Serial.printf("FS Upload: started \"%s\" (%u bytes)\n", path.c_str(), upload.totalSize);
+
+  } else if (upload.status == UPLOAD_FILE_WRITE) {
+    if (fsUploadFile) {
+      fsUploadFile.write(upload.buf, upload.currentSize);
+    }
+
+  } else if (upload.status == UPLOAD_FILE_END) {
+    if (fsUploadFile) {
+      fsUploadFile.close();
+      Serial.printf("FS Upload: finished \"%s\" (%u bytes)\n", upload.filename.c_str(), upload.totalSize);
+    }
   }
 }
 

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -253,6 +253,13 @@ void WebPortal::setupRoutes() {
     apiSaveSensorMapping();
   });
 
+  // LittleFS file upload (for OTA-safe web asset deployment)
+  server_.on("/api/fs/upload", HTTP_POST, []() {
+    if (!handleAuthentication())
+      return;
+    apiFsUpload();
+  });
+
   // OTA Firmware handling (manual upload via web form)
   server_.on(
     "/api/update", HTTP_POST,
@@ -1063,6 +1070,53 @@ void WebPortal::apiSaveSensorMapping() {
   }
 
   server_.send(200, "application/json", "{\"status\":\"ok\",\"message\":\"Sensor mapping saved. Reboot to apply.\"}");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// LittleFS file upload handler
+// ═══════════════════════════════════════════════════════════════════════
+
+void WebPortal::apiFsUpload() {
+  if (!server_.hasArg("path") || !server_.hasArg("content")) {
+    server_.send(400, "text/plain", "Missing path or content");
+    return;
+  }
+
+  String path = server_.arg("path");
+
+  // Security: only allow files under /web/
+  if (!path.startsWith("/web/")) {
+    server_.send(403, "text/plain", "Only /web/ paths allowed");
+    return;
+  }
+
+  // Security: prevent path traversal
+  if (path.indexOf("..") != -1) {
+    server_.send(403, "text/plain", "Path traversal not allowed");
+    return;
+  }
+
+  // Ensure the /web/ directory exists
+  if (!LittleFS.exists("/web")) {
+    LittleFS.mkdir("/web");
+  }
+
+  String content = server_.arg("content");
+
+  File f = LittleFS.open(path, "w");
+  if (!f) {
+    server_.send(500, "text/plain", "Failed to open file for writing");
+    return;
+  }
+
+  size_t written = f.print(content);
+  f.close();
+
+  if (written == content.length()) {
+    server_.send(200, "text/plain", "OK");
+  } else {
+    server_.send(500, "text/plain", "Write incomplete");
+  }
 }
 
 }  // namespace PoolController

--- a/src/WebPortal.hpp
+++ b/src/WebPortal.hpp
@@ -114,6 +114,8 @@ private:
   static void apiGetSensors();
   /** @brief POST /api/sensors/map — save sensor-to-role address mapping to NVS. */
   static void apiSaveSensorMapping();
+  /** @brief POST /api/fs/upload — upload a file to LittleFS (OTA-safe web asset deployment). */
+  static void apiFsUpload();
 
   static WebServer server_;
   static DNSServer dnsServer_;

--- a/src/WebPortal.hpp
+++ b/src/WebPortal.hpp
@@ -116,6 +116,8 @@ private:
   static void apiSaveSensorMapping();
   /** @brief POST /api/fs/upload — upload a file to LittleFS (OTA-safe web asset deployment). */
   static void apiFsUpload();
+  /** @brief Streaming upload handler for /api/fs/upload multipart file data. */
+  static void handleFsUploadStream();
 
   static WebServer server_;
   static DNSServer dnsServer_;

--- a/test/native/mocks/Arduino.h
+++ b/test/native/mocks/Arduino.h
@@ -436,7 +436,9 @@ class LittleFSClass {
 public:
   bool begin(bool) { return true; }
   bool exists(const char *) { return false; }
+  bool mkdir(const char *) { return true; }
   File open(const char *, const char * = "r") { return File(); }
+  File open(const String &path, const char *mode = "r") { return open(path.c_str(), mode); }
   bool remove(const char *) { return true; }
   bool rename(const char *, const char *) { return true; }
   void end() {}


### PR DESCRIPTION
## Summary

Das Dashboard (Temperaturen, Pumpenstatus, Operation Mode, Betriebsparameter) ist jetzt ohne Login sichtbar — **read-only**.

## Changes

### Backend (`src/WebPortal.cpp`)
- **`handleRoot()`**: Auth-Check entfernt — Dashboard HTML wird immer ausgeliefert
- **`apiGetStatus()`**: `authenticated` Flag hinzugefügt + alle Betriebsparameter (`loop_interval`, `temp_hysteresis`, `temp_circ_*`, `timezone`, `ntp_server`, etc.)
- **JSON Buffer**: 1024→1536 Bytes für die zusätzlichen Felder
- **`/api/sensors` GET**: Auth entfernt — Sensordaten sind ohne Login lesbar (POST bleibt geschützt)

### Frontend (`data/web/index.html`)
- Login-Banner mit "Sign In for full access" Button
- Login-Modal (Overlay) als Alternative zur separaten /login Seite

### Frontend (`data/web/app.js`)
- `isAuthenticated` State aus `/api/status`
- `updateAuthUI()` gated alle interaktiven Controls:
  - **Dashboard**: Pump-Toggle, Mode-Buttons, Temp-Klicks deaktiviert
  - **Pool/Time-Tabs**: Inputs/Selects/Buttons auf `disabled`
  - **WiFi/MQTT/System/Sensors-Tabs**: ausgeblendet
  - **More-Menu**: Nur "About" visible
  - Login-Banner ein/aus

## Testing
- Beide Targets gebuildet: `esp32dev` ✅, `norvi_ae01_r` ✅
- Dashboard lädt und zeigt Daten ohne Session-Cookie
- Nach Login (Seite reload) sind alle interaktiven Funktionen verfügbar