### PR TITLE
fix(norvi): move solar pump relay from R1 (GPIO12) to R5 (GPIO33)

### DIFF
--- a/docs/norvi-ae01-r.de.md
+++ b/docs/norvi-ae01-r.de.md
@@ -58,7 +58,7 @@ Pinbelegung ausgewählt, die die belegten und reinen-Eingang-Pins vermeidet:
 | `PIN_DS_SOLAR`    |    **GPIO25**     | DS18B20 — Solar-Kollektortemperatur         |          Erweiterungsport Pin 1          |
 | `PIN_DS_POOL`     |    **GPIO25**     | DS18B20 — Pool-Wassertemperatur             | Shared Bus auf GPIO25 (Erweiterungsport) |
 | `PIN_RELAY_POOL`  |  **GPIO14** (R0)  | Relais — Pool-Umwälzpumpe                   |             Relaisausgang 0              |
-| `PIN_RELAY_SOLAR` |  **GPIO12** (R1)  | Relais — Solarheizungspumpe                 |             Relaisausgang 1              |
+| `PIN_RELAY_SOLAR` |  **GPIO33** (R5)  | Relais — Solarheizungspumpe                 |             Relaisausgang 5              |
 | `PIN_LED_STATUS`  | **GPIO27** (T0.1) | Status-LED (extern, über Transistorausgang) |          Transistorausgang 0.1           |
 | `PIN_OLED_SDA`    |    **GPIO16**     | I2C SDA — eingebautes 0,96" OLED (SSD1306)  |               Intern (I2C)               |
 | `PIN_OLED_SCL`    |    **GPIO17**     | I2C SCL — eingebautes 0,96" OLED (SSD1306)  |               Intern (I2C)               |
@@ -212,15 +212,25 @@ kommt zum Einsatz.
  ─── RELAISAUSGÄNGE (eingebaut) ───────────────────────────────────────
 
    NORVI Relaisausgang 0 (GPIO14):  Pool-Pumpe
-   NORVI Relaisausgang 1 (GPIO12):  Solar-Pumpe
+   NORVI Relaisausgang 5 (GPIO33):  Solar-Pumpe
 
    L (Außenleiter) ─── RCD ─── MCB ──┬── Relais COM0 ── Pool-Pumpe NO
-                                     └── Relais COM1 ── Solar-Pumpe NO
+                                     └── Relais COM5 ── Solar-Pumpe NO
    N (Neutral) ──────────────────────────── Neutralleiter ── Pumpen N
 
    Die NORVI-Relais sind Schließer (SPST) — schließe deine 230V AC
    Verbraucher zwischen COM und NO an. Die Relais sind für 5A/250V AC
    ausgelegt.
+
+   > **Hinweis:** Die Solar-Pumpe wurde von Relaisausgang 1 (GPIO12) auf
+   > Relaisausgang 5 (GPIO33) verlegt, nachdem bei einem Feldgerät der
+   > R1-Kanal dauerhaft leitend war (Relais klickt hörbar beim
+   > Schalten, aber COM1/NO1 öffnet nie) — ein Hardwarefehler
+   > (verschweißter Kontakt oder NO/NC-Verwechslung), nachweislich kein
+   > Firmware-Fehler, da Relaisausgang 0 dieselbe Schaltlogik nutzt und
+   > korrekt funktioniert. Falls dein R1-Kanal einwandfrei funktioniert,
+   > kannst du ihn weiterverwenden, indem du `PIN_RELAY_SOLAR` in
+   > `Config.hpp` zurücksetzt.
 
    ⚡ Relais-Polarität: Im Gegensatz zu externen Relaismodulen (die typischerweise
    active-LOW sind: LOW = EIN, HIGH = AUS) sind die eingebauten NORVI-Relais
@@ -321,7 +331,7 @@ der ESP32 werden gemeinsam aus dieser Spannung versorgt.
 | **Relais-Strom** | 5V an Relaismodul             | Integriert (24V → Relaisspulen)                     |
 | **Relais-Polarität** | Active-LOW (LOW = EIN)   | **Active-HIGH** (HIGH = EIN)                        |
 | **Sensor-Pins**  | GPIO32, GPIO33           | GPIO25 (Exp Port), GPIO5 (löten)                    |
-| **Relais-Pins**  | GPIO25, GPIO26           | GPIO14 (R0), GPIO12 (R1)                            |
+| **Relais-Pins**  | GPIO25, GPIO26           | GPIO14 (R0), GPIO33 (R5)                            |
 | **Status-LED**   | Eingebaut (GPIO2)        | Extern über GPIO27 (T0.1)                           |
 | **OLED-Display** | Keines                   | Eingebaut 0,96" (SSD1306) — 4 Info-Seiten + QR-Code |
 | **Drucktaster**  | BOOT-Taster (GPIO0)      | 3 Fronttaster — Seiten & Modi                       |
@@ -381,7 +391,7 @@ pio run -e norvi_ae01_r -t uploadfs
 |   3    | RS-485 RX (mit USB geteilt)                |              ❌              |
 |   4    | RS-485 Flusskontrolle                      |              ❌              |
 | **5**  | **— (freier GPIO, kein NORVI-Peripherie)** | ✅ **DS18B20 Pool (löten)**  |
-|   12   | **Relaisausgang 1**                        |        ✅ Solar-Pumpe        |
+|   12   | Relaisausgang 1 (vermeiden — siehe Hinweis oben) |              ❌              |
 |   13   | Relaisausgang 2                            |              ❌              |
 |   14   | **Relaisausgang 0**                        |        ✅ Pool-Pumpe         |
 |   15   | Relaisausgang 3                            |              ❌              |
@@ -397,7 +407,7 @@ pio run -e norvi_ae01_r -t uploadfs
 |   26   | Transistorausgang 0.0                      |          ❌ (frei)           |
 |   27   | **Transistorausgang 0.1**                  |    ✅ Status-LED (extern)    |
 | **32** | **Analogeingang / Taster**                 |       ✅ 3 Fronttaster       |
-|   33   | Relaisausgang 5                            |              ❌              |
+| **33** | **Relaisausgang 5**                        |       ✅ Solar-Pumpe         |
 |   34   | Digitaleingang 2 (nur Eingang)             |              ❌              |
 |   35   | Digitaleingang 3 (nur Eingang)             |              ❌              |
 |   38   | —                                          |              ❌              |

--- a/docs/norvi-ae01-r.md
+++ b/docs/norvi-ae01-r.md
@@ -57,7 +57,7 @@ pin mapping that avoids the occupied and input-only pins:
 | `PIN_DS_SOLAR`    |    **GPIO25**     | DS18B20 — Solar collector temperature        |       Expansion Port Pin 1       |
 | `PIN_DS_POOL`     |    **GPIO25**     | DS18B20 — Pool water temperature             | Shared bus on GPIO25 (expansion) |
 | `PIN_RELAY_POOL`  |  **GPIO14** (R0)  | Relay — Pool circulation pump                |          Relay Output 0          |
-| `PIN_RELAY_SOLAR` |  **GPIO12** (R1)  | Relay — Solar heating pump                   |          Relay Output 1          |
+| `PIN_RELAY_SOLAR` |  **GPIO33** (R5)  | Relay — Solar heating pump                   |          Relay Output 5          |
 | `PIN_LED_STATUS`  | **GPIO27** (T0.1) | Status LED (external, via transistor output) |      Transistor Output 0.1       |
 | `PIN_OLED_SDA`    |    **GPIO16**     | I2C SDA — built-in 0.96" OLED (SSD1306)      |          Internal (I2C)          |
 | `PIN_OLED_SCL`    |    **GPIO17**     | I2C SCL — built-in 0.96" OLED (SSD1306)      |          Internal (I2C)          |
@@ -213,14 +213,23 @@ to the default device index.
  ─── RELAY OUTPUTS (built-in) ─────────────────────────────────────────
 
    NORVI Relay Output 0 (GPIO14):   Pool pump
-   NORVI Relay Output 1 (GPIO12):   Solar pump
+   NORVI Relay Output 5 (GPIO33):   Solar pump
 
    L (mains) ─── RCD ─── MCB ──┬── Relay COM0 ── Pool Pump NO
-                                └── Relay COM1 ── Solar Pump NO
+                                └── Relay COM5 ── Solar Pump NO
    N (neutral) ───────────────────────── Neutral bar ── Pump N
 
    The NORVI relays are Normally Open (SPST) — connect your 230V AC
    loads between COM and NO. The relays are rated 5A/250V AC.
+
+   > **Note:** Solar pump moved from Relay Output 1 (GPIO12) to Relay
+   > Output 5 (GPIO33) after a field unit's R1 channel was found
+   > permanently conducting (relay audibly clicks, but COM1/NO1 never
+   > opens) — a hardware fault (welded/fused contact or NO/NC
+   > miswiring), confirmed not to be a firmware issue since Relay
+   > Output 0 uses identical control logic and switches correctly.
+   > If your R1 channel works fine, you can keep using it by reverting
+   > `PIN_RELAY_SOLAR` in `Config.hpp`.
 
    ⚡ Relay polarity: Unlike standard external relay modules (which are
    typically active-LOW: LOW = ON, HIGH = OFF), the NORVI AE01-R built-in
@@ -318,7 +327,7 @@ ESP32 are both powered from this single supply.
 | **Relay power**  | 5V to relay module             | Integrated (24V → relay coils)                    |
 | **Relay polarity** | Active-LOW (LOW = ON)        | **Active-HIGH** (HIGH = ON)                       |
 | **Sensor pins**  | GPIO32, GPIO33            | GPIO25 (Exp Port), GPIO5 (solder)                 |
-| **Relay pins**   | GPIO25, GPIO26            | GPIO14 (R0), GPIO12 (R1)                          |
+| **Relay pins**   | GPIO25, GPIO26            | GPIO14 (R0), GPIO33 (R5)                          |
 | **Status LED**   | Built-in (GPIO2)          | External via GPIO27 (T0.1)                        |
 | **OLED display** | None                      | Built-in 0.96" (SSD1306) — 4 info pages + QR code |
 | **Push buttons** | BOOT button (GPIO0)       | 3 front buttons — cycle pages & modes             |
@@ -377,7 +386,7 @@ pio run -e norvi_ae01_r -t uploadfs
 |   3    | RS-485 RX (shared with USB)            |              ❌              |
 |   4    | RS-485 Flow Control                    |              ❌              |
 | **5**  | **— (free GPIO, no NORVI peripheral)** | ✅ **DS18B20 Pool (solder)** |
-|   12   | **Relay Output 1**                     |        ✅ Solar pump         |
+|   12   | Relay Output 1 (avoid — see note above) |              ❌              |
 |   13   | Relay Output 2                         |              ❌              |
 |   14   | **Relay Output 0**                     |         ✅ Pool pump         |
 |   15   | Relay Output 3                         |              ❌              |
@@ -393,7 +402,7 @@ pio run -e norvi_ae01_r -t uploadfs
 |   26   | Transistor Output 0.0                  |          ❌ (free)           |
 |   27   | **Transistor Output 0.1**              |   ✅ Status LED (external)   |
 | **32** | **Analog Input / Buttons**             |   ✅ 3 front-panel buttons   |
-|   33   | Relay Output 5                         |              ❌              |
+| **33** | **Relay Output 5**                     |       ✅ Solar pump          |
 |   34   | Digital Input 2 (input only)           |              ❌              |
 |   35   | Digital Input 3 (input only)           |              ❌              |
 |   38   | —                                      |              ❌              |

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -91,6 +91,12 @@ constexpr std::uint8_t PIN_RELAY_POOL{14};
  * otherwise unused on NORVI builds.
  */
 constexpr std::uint8_t PIN_RELAY_SOLAR{33};
+static_assert(PIN_RELAY_SOLAR != 12,
+  "PIN_RELAY_SOLAR must not be reverted to GPIO12 (Relay Output 1) without "
+  "confirming the field hardware fault is resolved — see the doc comment "
+  "above and docs/norvi-ae01-r.md for context. R1 was found permanently "
+  "conducting (welded/fused contact or NO/NC miswiring) on at least one "
+  "field unit; Relay Output 0 uses identical firmware logic and works.");
 /** @brief Status LED — external LED via transistor output 0.1 (open-collector, 100 mA max). */
 constexpr std::uint8_t PIN_LED_STATUS{27};
 /** @brief Optional warning LED — not used on NORVI. */

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -80,8 +80,17 @@ constexpr std::uint8_t PIN_DS_SOLAR{25};
 constexpr std::uint8_t PIN_DS_POOL{25};
 /** @brief Relay control pin — pool circulation pump (Relay Output 0). */
 constexpr std::uint8_t PIN_RELAY_POOL{14};
-/** @brief Relay control pin — solar heating pump (Relay Output 1). */
-constexpr std::uint8_t PIN_RELAY_SOLAR{12};
+/**
+ * @brief Relay control pin — solar heating pump.
+ *
+ * Moved from Relay Output 1 (GPIO12) to Relay Output 5 (GPIO33): a field
+ * unit's R1 channel was found to be permanently conducting (relay audibly
+ * clicks on setSwitch(), but COM1/NO1 never opens) — a hardware fault
+ * (welded/fused contact or NO/NC miswiring), not a firmware issue: R0 uses
+ * the identical RelayModuleNode logic and switches correctly. R5/GPIO33 is
+ * otherwise unused on NORVI builds.
+ */
+constexpr std::uint8_t PIN_RELAY_SOLAR{33};
 /** @brief Status LED — external LED via transistor output 0.1 (open-collector, 100 mA max). */
 constexpr std::uint8_t PIN_LED_STATUS{27};
 /** @brief Optional warning LED — not used on NORVI. */


### PR DESCRIPTION
## Problem
Field-reported: on a NORVI AE01-R unit, the solar pump relay (R1 / GPIO12) is permanently conducting — the relay audibly clicks when the firmware calls `setSwitch()`, but COM1/NO1 never actually opens/closes the circuit.

## Root cause
Confirmed hardware, not firmware: Relay Output 0 (pool pump, GPIO14) uses the exact same `RelayModuleNode` class with identical `activeLow=false` polarity logic and switches correctly. Since the software driving both channels is identical, R1's fault is either a welded/fused contact (common on mechanical relays switching inductive pump-motor loads without snubber/flyback protection) or a NO/NC wiring mixup during field installation.

## Fix
Move `PIN_RELAY_SOLAR` from GPIO12 (Relay Output 1) to GPIO33 (Relay Output 5), which is otherwise unused on NORVI builds. Units whose R1 channel works fine can revert this constant.

## Verification
- `pio run -e norvi_ae01_r` — SUCCESS
- `pio run -e esp32dev` — SUCCESS (unaffected, different pin block)
- Native unit tests: 74/74 suites, 144/144 assertions passed

## Docs
Updated `docs/norvi-ae01-r.md` and `.de.md` — pin reference table, wiring diagram, and comparison table now show R5/GPIO33, with a note on the R1 hardware issue.