### PR TITLE
fix(sensor): apply address filter to running instance immediately

### DIFF
--- a/src/DallasTemperatureNode.cpp
+++ b/src/DallasTemperatureNode.cpp
@@ -57,11 +57,69 @@ DallasTemperatureNode::DallasTemperatureNode(
 void DallasTemperatureNode::setAddressFilter(const DeviceAddress addr) {
   memcpy(filterAddr_, addr, sizeof(DeviceAddress));
   hasFilter_ = true;
+
+  if (numberOfDevices > 0) {
+    resolveFilter();
+  }
 }
 
 void DallasTemperatureNode::clearAddressFilter() {
   memset(filterAddr_, 0, sizeof(DeviceAddress));
   hasFilter_ = false;
+
+  if (numberOfDevices > 0) {
+    resolveFilter();
+  }
+}
+
+bool DallasTemperatureNode::resolveFilter() {
+  DallasTemperature *activeSensor = sharedSensor_ ? sharedSensor_ : &sensor;
+
+  if (hasFilter_ && numberOfDevices > 0) {
+    // ── Address filter active: find the matching device on the bus ──
+    for (uint8_t i = 0; i < numberOfDevices; i++) {
+      DeviceAddress addr;
+      if (activeSensor->getAddress(addr, i)) {
+        if (memcmp(addr, filterAddr_, sizeof(DeviceAddress)) == 0) {
+          deviceIndex_ = i;
+          memcpy(deviceAddress_, addr, sizeof(DeviceAddress));
+          _sensorFound = true;
+          char adr[18];
+          address2String(addr, adr, sizeof(adr));
+          Serial.printf("  ◦ %s: filter resolved → device %d [%s] ✓\n", _id, i, adr);
+          return true;
+        }
+      }
+    }
+    // Filter address not found on bus — fall back to deviceIndex_
+    Serial.printf("  ✖ %s: filter address not found on bus! "
+                  "Falling back to device index %d\n",
+      _id, deviceIndex_);
+    if (activeSensor->getAddress(deviceAddress_, deviceIndex_)) {
+      _sensorFound = true;
+      return true;
+    }
+    _sensorFound = false;
+    return false;
+  }
+
+  if (numberOfDevices > 0) {
+    // ── No filter: cache address by deviceIndex_ ───────────────────
+    if (activeSensor->getAddress(deviceAddress_, deviceIndex_)) {
+      _sensorFound = true;
+      char adr[18];
+      address2String(deviceAddress_, adr, sizeof(adr));
+      Serial.printf("  ◦ %s: no filter → device %d [%s]", _id, deviceIndex_, adr);
+      if (sharedSensor_) {
+        Serial.print(" (shared bus)");
+      }
+      Serial.println();
+      return true;
+    }
+  }
+
+  _sensorFound = false;
+  return false;
 }
 
 void DallasTemperatureNode::getDeviceAddressString(char *buffer, size_t size) const {
@@ -117,44 +175,7 @@ void DallasTemperatureNode::begin() {
     }
 
     // ── Resolve address filter (persistent mapping) ─────────────────────
-    if (hasFilter_) {
-      bool found = false;
-      for (uint8_t i = 0; i < numberOfDevices; i++) {
-        DeviceAddress addr;
-        if (activeSensor->getAddress(addr, i)) {
-          if (memcmp(addr, filterAddr_, sizeof(DeviceAddress)) == 0) {
-            deviceIndex_ = i;
-            memcpy(deviceAddress_, addr, sizeof(DeviceAddress));
-            _sensorFound = true;
-            found = true;
-            char adr[18];
-            address2String(addr, adr, sizeof(adr));
-            Serial.printf("  ◦ %s: matched address filter → device %d [%s] ✓\n", _id, i, adr);
-            break;
-          }
-        }
-      }
-      if (!found) {
-        Serial.printf("  ✖ %s: address filter not found! "
-                      "Falling back to device index %d\n",
-          _id, deviceIndex_);
-        if (activeSensor->getAddress(deviceAddress_, deviceIndex_)) {
-          _sensorFound = true;
-        }
-      }
-    } else {
-      // ── No filter: cache address by deviceIndex_ ─────────────────────
-      if (activeSensor->getAddress(deviceAddress_, deviceIndex_)) {
-        _sensorFound = true;
-        char adr[18];
-        address2String(deviceAddress_, adr, sizeof(adr));
-        Serial.printf("  ◦ %s: no filter → device %d [%s]", _id, deviceIndex_, adr);
-        if (sharedSensor_) {
-          Serial.print(" (shared bus)");
-        }
-        Serial.println();
-      }
-    }
+    resolveFilter();
 
     // ── Report global status ───────────────────────────────────────────
     if (sharedSensor_) {

--- a/src/DallasTemperatureNode.cpp
+++ b/src/DallasTemperatureNode.cpp
@@ -81,7 +81,9 @@ bool DallasTemperatureNode::resolveFilter() {
       DeviceAddress addr;
       if (activeSensor->getAddress(addr, i)) {
         if (memcmp(addr, filterAddr_, sizeof(DeviceAddress)) == 0) {
-          deviceIndex_ = i;
+          // Note: intentionally NOT updating deviceIndex_ here — the constructor-
+          // provided default (solar=0, pool=1) must survive as the fallback index
+          // used by the no-filter path in clearAddressFilter().
           memcpy(deviceAddress_, addr, sizeof(DeviceAddress));
           _sensorFound = true;
           char adr[18];

--- a/src/DallasTemperatureNode.hpp
+++ b/src/DallasTemperatureNode.hpp
@@ -131,6 +131,11 @@ private:
 
   uint8_t numberOfDevices;
 
+  /** @brief Scan the bus for the current filter and update deviceAddress_.
+   *  Called by begin(), setAddressFilter(), and clearAddressFilter().
+   *  @return true if the device was found, false if fallback was used. */
+  bool resolveFilter();
+
   /** @brief Format a DeviceAddress as a hex string. */
   void address2String(const DeviceAddress deviceAddress, char *buffer, size_t size) const;
 };


### PR DESCRIPTION
## Beschreibung

Das Setzen der Sensor-Zuordnung (Solar/Pool) funktionierte weder über die WebUI noch über Home Assistant, weil `setAddressFilter()` zwar `filterAddr_` speicherte, aber `deviceAddress_` nicht aktualisierte. Die `loop()`-Methode im Shared-Bus-Modus (NORVI AE01-R) liest die Temperatur von `deviceAddress_` – daher änderte sich die Messung nicht, auch wenn das Mapping gespeichert wurde.

## Root Cause

```cpp
// ALT — deviceAddress_ wurde nie aktualisiert
void DallasTemperatureNode::setAddressFilter(const DeviceAddress addr) {
  memcpy(filterAddr_, addr, sizeof(DeviceAddress));
  hasFilter_ = true;
}
```

## Fix

1. Filter-Auflösungslogik aus `begin()` in `resolveFilter()` extrahiert
2. `setAddressFilter()` / `clearAddressFilter()` rufen `resolveFilter()` auf
3. `begin()` verwendet ebenfalls `resolveFilter()`

## Betroffene Pfade

- **WebUI**: `apiSaveSensorMapping()` → `setAddressFilter()`
- **Home Assistant**: `handleMqttMessage()` → `setAddressFilter()`

NVS-Persistierung bleibt unverändert.

## Build

- ✅ esp32dev: SUCCESS
- ✅ norvi_ae01_r: SUCCESS
- ✅ OTA-Update auf NORVI AE01-R getestet