### PR TITLE
fix(web): stop tabs from reopening WiFi settings after navigation

### DIFF
--- a/data/web/app.js
+++ b/data/web/app.js
@@ -186,10 +186,14 @@ async function loadTelemetry() {
       if (etEl) etEl.value = pad2(data.timer_end_h) + ':' + pad2(data.timer_end_m);
     }
 
-    // AP-Mode: WiFi-Tab anzeigen (nur einmalig — nicht bei jedem Poll erzwingen,
-    // sonst überschreibt es die manuelle Tab-Navigation des Nutzers)
+    // AP-Mode: WiFi-Tab anzeigen
     if (data.ap_mode) {
-      if (!hasAutoSwitchedToWifi) {
+      if (!isAuthenticated) {
+        // Ohne Auth immer zum WiFi-Tab (Captive Portal / AP-Setup) —
+        // der Nutzer muss sich verbinden können, kein freies Navigieren nötig
+        switchTab('wifi');
+      } else if (!hasAutoSwitchedToWifi) {
+        // Nach Login: einmalig WiFi-Tab zeigen, dann freie Navigation erlauben
         switchTab('wifi');
         hasAutoSwitchedToWifi = true;
       }

--- a/data/web/app.js
+++ b/data/web/app.js
@@ -37,6 +37,7 @@ console.log('[pool] app.js loaded, version=2026-06-05');
 // ── Auth State ──
 
 let isAuthenticated = false;
+let hasAutoSwitchedToWifi = false;  // one-shot guard so AP-mode redirect doesn't fight user navigation
 
 async function loadTelemetry() {
   try {
@@ -185,9 +186,15 @@ async function loadTelemetry() {
       if (etEl) etEl.value = pad2(data.timer_end_h) + ':' + pad2(data.timer_end_m);
     }
 
-    // AP-Mode: WiFi-Tab anzeigen
+    // AP-Mode: WiFi-Tab anzeigen (nur einmalig — nicht bei jedem Poll erzwingen,
+    // sonst überschreibt es die manuelle Tab-Navigation des Nutzers)
     if (data.ap_mode) {
-      switchTab('wifi');
+      if (!hasAutoSwitchedToWifi) {
+        switchTab('wifi');
+        hasAutoSwitchedToWifi = true;
+      }
+    } else {
+      hasAutoSwitchedToWifi = false;
     }
 
     // About Tab – system info
@@ -255,11 +262,13 @@ function updateAuthUI() {
   const tabBar = document.getElementById('tabBar');
   if (tabBar) tabBar.style.display = isAuthenticated ? '' : 'none';
 
-  // Tab visibility
+  // Tab visibility — only ever force-hide when unauthenticated. Never force-show:
+  // switchTab() is the sole authority for which tab is currently visible, otherwise
+  // this would re-reveal a hidden tab on every poll and fight user navigation.
   const tabsToHide = ['tab-sensors'];
   for (const id of tabsToHide) {
     const el = document.getElementById(id);
-    if (el) el.style.display = isAuthenticated ? '' : 'none';
+    if (el && !isAuthenticated) el.style.display = 'none';
   }
 
   // Hide Sensors tab button
@@ -298,10 +307,14 @@ function updateAuthUI() {
     }
   }
 
-  // System / WiFi / MQTT / Sensors tabs: fully hide when not authenticated
+  // System / WiFi / MQTT / Sensors tabs: fully hide when not authenticated. Never
+  // force-show here — that previously used `''` (empty string), which falls back
+  // to the CSS default `display:block`, making the tab visible again on every 2s
+  // poll regardless of which tab switchTab() had actually activated (the reported
+  // "always jumps back to WiFi Settings" bug).
   for (const id of ['tab-system', 'tab-wifi', 'tab-mqtt']) {
     const el = document.getElementById(id);
-    if (el && el.style.display !== 'block') el.style.display = isAuthenticated ? '' : 'none';
+    if (el && !isAuthenticated) el.style.display = 'none';
   }
 
   // Sensors tab: disable radio buttons and hide save bar

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -1104,13 +1104,21 @@ void WebPortal::handleFsUploadStream() {
       fsUploadFile.close();
     }
 
-    // Resolve the target path from the multipart form field "path"
-    if (!server_.hasArg("path")) {
+    // Resolve the target path — try multipart form field "path" first,
+    // then fall back to upload.filename (which is set from the Content-Disposition
+    // filename attribute). server_.arg("path") is unreliable during the upload
+    // callback because the multipart arg parser may not have finished yet for
+    // fields that arrive before the file part.
+    String path;
+    if (server_.hasArg("path")) {
+      path = server_.arg("path");
+    } else if (upload.filename.length() > 0) {
+      path = upload.filename;
+    }
+    if (path.length() == 0) {
       Serial.println("FS Upload: missing path argument — aborting");
       return;
     }
-
-    String path = server_.arg("path");
 
     // Security: only allow files under /web/
     if (!path.startsWith("/web/")) {


### PR DESCRIPTION
## Problem

Nach dem Umbau auf ein Read-only-Dashboard ohne Login (PR #155) konnte man nach dem Login nicht mehr richtig navigieren: egal welcher Tab ausgewählt wurde (z. B. Sensoren), landete nach ~2 Sekunden immer wieder bei WiFi Settings.

## Root Causes

### 1. Frontend: `updateAuthUI()` überschrieb Tab-Sichtbarkeit

`updateAuthUI()` (läuft bei jedem 2s-Telemetrie-Poll) setzte `element.style.display = ''` für Admin-Tabs (WiFi/MQTT/System/Sensors). Der leere String entfernt das Inline-`display:none`, sodass die Divs auf CSS-Default `display:block` zurückfallen — unabhängig davon, welchen Tab `switchTab()` aktiv gesetzt hatte. Da `tab-wifi` im DOM vor den anderen liegt, gewann es visuell → Sprung zu WiFi Settings.

**Fix:** `updateAuthUI()` versteckt Tabs nur noch bei `!isAuthenticated`. `switchTab()` bleibt alleinige Instanz für Sichtbarkeit. Der AP-Mode-Redirect zum WiFi-Tab feuert jetzt einmalig statt bei jedem Poll.

### 2. Backend: `/api/fs/upload` hat nie geschrieben

`server_.arg("path")` liefert während des Upload-Callbacks keinen Wert, weil der ESP32-WebServer-Multipart-Parser Textfelder nicht parst, bevor der Datei-Upload verarbeitet wird. Der Handler meldete `200 OK`, aber die Datei wurde nie geöffnet.

**Fix:** Fallback auf `upload.filename` (Content-Disposition filename-Attribut) wenn `server_.arg("path")` nicht verfügbar ist.

## Testing

- JS-Syntax-Check: `node --check`
- Firmware-Build: ✅ (Flash 96.5%)
- OTA-Flash: ✅
- Web-Asset-Deployment via neuem `curl -F "content=@app.js;filename=/web/app.js"`: ✅
- Verifikation: Fix-Code im ausgelieferten `app.js` bestätigt