### PR TITLE
fix(docs): correct relative paths for images and download links

### DIFF
--- a/docs/hardware-guide.de.md
+++ b/docs/hardware-guide.de.md
@@ -238,7 +238,7 @@ zu wechseln. Active-high-Module sind einfacher in der Handhabung.
 
 {{< figure
   library="true"
-  src="../pool-controller_breadboard.png"
+  src="pool-controller_breadboard.png"
   title="Pool-Controller Breadboard-Aufbau mit ESP32, zwei DS18B20-Temperatursensoren, 4,7kΩ-Pull-Up-Widerständen und 2-Kanal-Relaismodul"
   lightbox="true" >}}
 
@@ -489,7 +489,7 @@ dem Standard für IoT-Statusanzeigen.
 
 ## Referenzen
 
-- Fritzing-Quelldatei: [pool-controller.fzz](https://github.com/smart-swimmingpool/pool-controller/raw/main/docs/pool-controller.fzz)
+- Fritzing-Quelldatei: [pool-controller.fzz](pool-controller.fzz)
 - [KiCad-Schaltplan: ESP32 Dev Board](kicad/esp32-dev-board/esp32-dev-board-schematic.pdf) — KiCad-9.0-PDF-Export
 - [KiCad-Schaltplan: NORVI AE01-R](kicad/norvi-ae01-r/norvi-ae01-r-schematic.pdf) — KiCad-9.0-PDF-Export
 - [NORVI AE01-R Konfigurationsanleitung](norvi-ae01-r.de.md) — Industrie-ESP32-Controller Pinbelegung & Verdrahtung

--- a/docs/hardware-guide.md
+++ b/docs/hardware-guide.md
@@ -227,7 +227,7 @@ a different module — active-high modules are easier to work with.
 
 {{< figure
   library="true"
-  src="../pool-controller_breadboard.png"
+  src="pool-controller_breadboard.png"
   title="Breadboard prototype with ESP32, DS18B20 sensors, 4.7kΩ pull-up resistors, and 2-channel relay module"
   lightbox="true" >}}
 
@@ -465,7 +465,7 @@ IoT device status indication. The LED is updated once per control loop cycle.
 
 ## References
 
-- Fritzing source file: [pool-controller.fzz](https://github.com/smart-swimmingpool/pool-controller/raw/main/docs/pool-controller.fzz)
+- Fritzing source file: [pool-controller.fzz](pool-controller.fzz)
 - [KiCad Schematic: ESP32 Dev Board](kicad/esp32-dev-board/esp32-dev-board-schematic.pdf) — KiCad 9.0 PDF export
 - [KiCad Schematic: NORVI AE01-R](kicad/norvi-ae01-r/norvi-ae01-r-schematic.pdf) — KiCad 9.0 PDF export
 - [NORVI AE01-R Configuration Guide](norvi-ae01-r.md) — industrial ESP32 controller pin mapping & wiring

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -159,12 +159,12 @@ Hier ist der **komplette Schaltplan** für den Pool Controller:
 
 ### 📸 Visuelle Anleitung
 
-> **🔗 [Fritzing-Datei herunterladen](https://github.com/smart-swimmingpool/pool-controller/raw/main/docs/pool-controller.fzz)**
+> **🔗 [Fritzing-Datei herunterladen](pool-controller.fzz)**
 > (Öffne mit [Fritzing](https://fritzing.org/))
 
 Hier ist ein **Beispiel-Foto** des Aufbaus:
 
-![Pool Controller Breadboard Aufbau](https://github.com/smart-swimmingpool/pool-controller/raw/main/docs/images/pool-controller_breadboard.png)
+![Pool Controller Breadboard Aufbau](pool-controller_breadboard.png)
 _Beispielaufbau auf einem Breadboard_
 
 ---


### PR DESCRIPTION
## Fixes

**Image paths**: Two breadboard image references used `../pool-controller_breadboard.png` (pointing to repo root) when the image is in the same `docs/` directory. Affected `hardware-guide.md` and `hardware-guide.de.md`.

**Quickstart image URL**: Pointed to `raw/main/docs/images/pool-controller_breadboard.png` — the `images/` subdirectory does not exist; the image is directly in `docs/`. Also switched to a relative path so it works locally and in any checkout context.

**Raw GitHub URLs**: Replaced `raw/main/docs/…` links (brittle — tied to the default branch tip) with relative file paths for the Fritzing download links in `quickstart.md`, `hardware-guide.md`, and `hardware-guide.de.md`.