### PR TITLE
feat(web): replace pump text toggle with visible toggle-switch controls

### DIFF
--- a/data/web/app.js
+++ b/data/web/app.js
@@ -61,22 +61,12 @@ async function loadTelemetry() {
       document.getElementById('solarThreshold').textContent = 'min ' + data.temp_min_solar.toFixed(1) + '°C';
     }
 
-    // Pumpen
+    // Pumpen — Toggle-Switches aktualisieren
     if (data.pool_pump != null) {
-      const el = document.getElementById('poolPump');
-      const isOn = data.pool_pump;
-      el.innerHTML = isOn
-        ? '<span style="color: #22c55e;">●</span> ON'
-        : '<span style="color: var(--text-muted);">○</span> OFF';
-      el.style.color = isOn ? '#22c55e' : 'var(--text-muted)';
+      setPumpSwitch('pool', data.pool_pump);
     }
     if (data.solar_pump != null) {
-      const el = document.getElementById('solarPump');
-      const isOn = data.solar_pump;
-      el.innerHTML = isOn
-        ? '<span style="color: #22c55e;">●</span> ON'
-        : '<span style="color: var(--text-muted);">○</span> OFF';
-      el.style.color = isOn ? '#22c55e' : 'var(--text-muted)';
+      setPumpSwitch('solar', data.solar_pump);
     }
 
     // Modus hervorheben
@@ -230,7 +220,7 @@ function updateAuthUI() {
 
   // Dashboard: disable interactive controls
   const interactiveSelectors = [
-    '.pump-card',                       // pump toggle
+    '.pump-switch-card',                // pump toggle switches
     '.mode-card',                       // mode buttons
     '#poolTemp',                        // max pool temp click
     '#solarTemp',                       // min solar temp click
@@ -242,6 +232,7 @@ function updateAuthUI() {
         if (el.dataset.origOnclick) {
           el.setAttribute('onclick', el.dataset.origOnclick);
         }
+        el.classList.remove('disabled');
       } else {
         if (!el.dataset.origCursor) el.dataset.origCursor = el.style.cursor;
         if (el.getAttribute('onclick')) {
@@ -249,13 +240,9 @@ function updateAuthUI() {
           el.removeAttribute('onclick');
         }
         el.style.cursor = 'default';
+        el.classList.add('disabled');
       }
     }
-  }
-
-  // Hide pump toggle hints
-  for (const el of document.querySelectorAll('.pump-toggle-hint')) {
-    el.style.display = isAuthenticated ? '' : 'none';
   }
 
   // Hide bottom tab bar when not authenticated — read-only dashboard only
@@ -415,6 +402,20 @@ async function saveMqtt() {
     body: 'type=mqtt&host=' + encodeURIComponent(host) + '&port=' + portVal + '&username=' + encodeURIComponent(user) + '&password=' + encodeURIComponent(pass)
   });
   if (res.status === 200) alert('MQTT config saved!');
+}
+
+// ── Pump Switch UI Helper ──
+
+function setPumpSwitch(pump, isOn) {
+  const toggle = document.getElementById(pump + 'PumpToggle');
+  const status = document.getElementById(pump + 'PumpStatus');
+  if (toggle) {
+    toggle.classList.toggle('on', isOn);
+  }
+  if (status) {
+    status.textContent = isOn ? 'ON' : 'OFF';
+    status.className = 'pump-switch-status ' + (isOn ? 'on' : 'off');
+  }
 }
 
 // ── Pump Toggle ──

--- a/data/web/index.html
+++ b/data/web/index.html
@@ -108,14 +108,28 @@
     </div>
 
     <!-- Pumpen -->
-    <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem;">
-      <div class="pump-card" style="background: var(--glass-bg); padding: 1rem; border-radius: 12px; border: 1px solid var(--panel-border); cursor: pointer;" onclick="togglePump('pool')">
-        <label style="font-weight: 600; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted);">Pool Pump <span class="pump-toggle-hint" style="color: var(--accent-solar); font-weight: 400; text-transform: none;">↻ toggle</span></label>
-        <div class="tel-val" id="poolPump" style="font-size: 1.4rem; font-weight: 700; margin-top: 0.25rem; color: var(--text-muted);">OFF</div>
+    <div class="pump-switches">
+      <div class="pump-switch-card" onclick="togglePump('pool')">
+        <div class="pump-switch-header">
+          <span class="pump-switch-name">Pool Pump</span>
+          <span class="pump-switch-toggle" id="poolPumpToggle">
+            <span class="pump-switch-track">
+              <span class="pump-switch-thumb"></span>
+            </span>
+          </span>
+        </div>
+        <div class="pump-switch-status off" id="poolPumpStatus">OFF</div>
       </div>
-      <div class="pump-card" style="background: var(--glass-bg); padding: 1rem; border-radius: 12px; border: 1px solid var(--panel-border); cursor: pointer;" onclick="togglePump('solar')">
-        <label style="font-weight: 600; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted);">Solar Pump <span class="pump-toggle-hint" style="color: var(--accent-solar); font-weight: 400; text-transform: none;">↻ toggle</span></label>
-        <div class="tel-val" id="solarPump" style="font-size: 1.4rem; font-weight: 700; margin-top: 0.25rem; color: var(--text-muted);">OFF</div>
+      <div class="pump-switch-card" onclick="togglePump('solar')">
+        <div class="pump-switch-header">
+          <span class="pump-switch-name">Solar Pump</span>
+          <span class="pump-switch-toggle" id="solarPumpToggle">
+            <span class="pump-switch-track">
+              <span class="pump-switch-thumb"></span>
+            </span>
+          </span>
+        </div>
+        <div class="pump-switch-status off" id="solarPumpStatus">OFF</div>
       </div>
     </div>
 

--- a/data/web/style.css
+++ b/data/web/style.css
@@ -375,8 +375,17 @@ input:focus, select:focus {
 
 /* Auth-gated: disabled state */
 .pump-switch-card.disabled {
-  opacity: 0.5;
+  opacity: 0.3;
   cursor: default;
+  filter: grayscale(0.6);
+}
+.pump-switch-card.disabled .pump-switch-track {
+  background: rgba(255, 255, 255, 0.06) !important;
+  box-shadow: none !important;
+}
+.pump-switch-card.disabled .pump-switch-thumb {
+  background: rgba(255, 255, 255, 0.3) !important;
+  box-shadow: none !important;
 }
 .pump-switch-card.disabled:hover {
   background: var(--glass-bg);

--- a/data/web/style.css
+++ b/data/web/style.css
@@ -281,42 +281,106 @@ input:focus, select:focus {
   transform: translateY(-2px);
 }
 
-/* ── Pump Toggle Cards ── */
-.pump-card {
+/* ── Pump Toggle Switches ── */
+.pump-switches {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+.pump-switch-card {
+  background: var(--glass-bg);
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border);
+  cursor: pointer;
   transition: all 0.3s ease;
   user-select: none;
 }
-.pump-card:hover {
+.pump-switch-card:hover {
   background: rgba(0, 180, 216, 0.1);
   transform: translateY(-2px);
 }
-.pump-card:active {
+.pump-switch-card:active {
   transform: translateY(0);
 }
-.pump-toggle-hint {
-  font-size: 0.6rem;
-  opacity: 0.5;
-  font-weight: 400;
+
+/* ── Switch Header: Label + Toggle ── */
+.pump-switch-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
-.pump-indicator {
+.pump-switch-name {
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+/* ── Toggle Track ── */
+.pump-switch-toggle {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.pump-switch-track {
+  position: relative;
   display: inline-block;
-  width: 10px;
-  height: 10px;
+  width: 48px;
+  height: 26px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 13px;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+.pump-switch-toggle.on .pump-switch-track {
+  background: #22c55e;
+  box-shadow:
+    inset 0 1px 3px rgba(0, 0, 0, 0.2),
+    0 0 10px rgba(34, 197, 94, 0.35);
+}
+
+/* ── Toggle Thumb ── */
+.pump-switch-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  background: #fff;
   border-radius: 50%;
-  vertical-align: middle;
-  margin-right: 4px;
-  transition: all 0.3s ease;
+  transition: transform 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
 }
-.pump-indicator.on {
-  background: var(--accent-blue);
-  box-shadow: 0 0 8px var(--accent-blue);
+.pump-switch-toggle.on .pump-switch-thumb {
+  transform: translateX(22px);
+  background: #fff;
 }
-.pump-indicator.off {
-  background: rgba(255, 255, 255, 0.15);
-  box-shadow: none;
+
+/* ── Pump Status Text ── */
+.pump-switch-status {
+  font-size: 0.75rem;
+  margin-top: 0.35rem;
+  font-weight: 600;
+  transition: color 0.3s ease;
 }
-.pump-card .tel-val.pump-auto {
-  opacity: 0.7;
+.pump-switch-status.on {
+  color: #22c55e;
+}
+.pump-switch-status.off {
+  color: var(--text-muted);
+}
+
+/* Auth-gated: disabled state */
+.pump-switch-card.disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.pump-switch-card.disabled:hover {
+  background: var(--glass-bg);
+  transform: none;
 }
 
 /* ── Mode Selector ── */


### PR DESCRIPTION
## Zusammenfassung

Die Pumpen-Steuerung im Dashboard zeigte bisher nur Text (`ON/OFF`) mit einem kleinen "↻ toggle"-Hinweis. Im manuellen Modus war nicht ausreichend sichtbar, dass man die Pumpen schalten kann.

## Änderungen

Ersetzt die einfachen Text-Cards durch echte iOS/Android-style Toggle-Switches mit:

- **Slider-Thumb** der bei ON nach rechts gleitet
- **Grüner Leuchteffekt** (`#22c55e`) im aktiven Zustand
- **Sanfte Übergänge** (cubic-bezier) beim Umschalten
- **Disabled-State** (50 % opacity) ohne Authentifizierung
- **Pumpen-Name** links, Switch rechts pro Karte

### Dateien

| Datei | Änderung |
|---|---|
| `data/web/index.html` | Pump-Card-Struktur durch Toggle-Switch-Container ersetzt |
| `data/web/style.css` | Vollständiges Toggle-Switch-Styling (Track, Thumb, Status, Disabled) |
| `data/web/app.js` | `setPumpSwitch()`-Helper, Telemetry nutzt neue IDs, `updateAuthUI()` nutzt neue Klassen |

## Preview

Vorher: Text-Card mit "↻ toggle"-Hinweis und ON/OFF-Text
Nachher: Karte mit Pumpen-Name + Toggle-Switch (Slider mit grünem Glow)

## Testing

- Kein C++-Code geändert — nur LittleFS-Webassets
- Nach `pio run --target uploadfs` sofort sichtbar