### PR TITLE
fix(logging): trace operation mode command sources

### DIFF
--- a/src/MqttPublisher.cpp
+++ b/src/MqttPublisher.cpp
@@ -1067,7 +1067,7 @@ void MqttPublisher::handleMqttMessage(
       return;
     }
     LOG_INFO("MQTT: Climate preset → pool mode \"%s\"\n", poolMode.c_str());
-    operationModeNode.setMode(poolMode.c_str());
+    operationModeNode.setMode(poolMode.c_str(), "mqtt:thermostat/preset");
     ConfigManager::getSettings().opMode = poolMode;
     ConfigManager::save();
     publishStates();
@@ -1088,7 +1088,7 @@ void MqttPublisher::handleMqttMessage(
       return;
     }
     LOG_INFO("MQTT: Climate mode → pool mode \"%s\"\n", poolMode.c_str());
-    operationModeNode.setMode(poolMode.c_str());
+    operationModeNode.setMode(poolMode.c_str(), "mqtt:thermostat/mode");
     ConfigManager::getSettings().opMode = poolMode;
     ConfigManager::save();
     publishStates();
@@ -1148,7 +1148,7 @@ void MqttPublisher::handleMqttMessage(
       return;
     }
 
-    operationModeNode.setMode(value.c_str());
+    operationModeNode.setMode(value.c_str(), "mqtt:mode/set");
     ConfigManager::getSettings().opMode = value;
     ConfigManager::save();
   } else if (top.endsWith("/pool-max-temp/set")) {

--- a/src/OperationModeNode.cpp
+++ b/src/OperationModeNode.cpp
@@ -113,22 +113,31 @@ Rule *OperationModeNode::getRule() {
 }
 
 bool OperationModeNode::setMode(String mode) {
+  return setMode(mode, "unspecified");
+}
+
+bool OperationModeNode::setMode(String mode, const char *source) {
+  if (source == nullptr) {
+    source = "unspecified";
+  }
   if (mode.equals(STATUS_AUTO) || mode.equals(STATUS_MANU) || mode.equals(STATUS_BOOST) || mode.equals(STATUS_TIMER)) {
-    // Reset temperature-based runtime extension on mode change
-    for (auto &rule : _ruleVec) {
-      rule->resetTemperatureExtension();
-    }
-    // Curated log event for MQTT event entity — only on actual mode change
     if (!_mode.equals(mode)) {
-      PoolController::LogCapture::logEvent("MODE_CHANGED", "Mode switched to %s", mode.c_str());
+      // Reset temperature-based runtime extension on mode change
+      for (auto &rule : _ruleVec) {
+        rule->resetTemperatureExtension();
+      }
+      PoolController::LogCapture::logEvent("MODE_CHANGED", "Mode changed %s -> %s (source=%s, persist=%s)", _mode.c_str(),
+        mode.c_str(), source, _suppressPersist ? "no" : "yes");
+      _mode = mode;
+      LOG_DEBUG("set mode: %s (source=%s)\n", _mode.c_str(), source);
+      if (!_suppressPersist)
+        saveState();
+    } else {
+      LOG_INFO("Mode set requested: %s -> %s (source=%s, changed=no, persist=no)\n", _mode.c_str(), mode.c_str(), source);
     }
-    _mode = mode;
-    LOG_DEBUG("set mode: %s\n", _mode.c_str());
-    if (!_suppressPersist)
-      saveState();
     return true;
   } else {
-    LOG_ERROR("✖ UNDEFINED Mode: %s. Current unchanged mode: %s\n", mode.c_str(), _mode.c_str());
+    LOG_ERROR("✖ UNDEFINED Mode: %s. Current unchanged mode: %s (source=%s)\n", mode.c_str(), _mode.c_str(), source);
     return false;
   }
 }
@@ -158,9 +167,8 @@ void OperationModeNode::loop() {
     if (rule != nullptr) {
       rule->loop();
     } else {
-      LOG_ERROR("  ✖ no rule defined for mode: %s. Falling back to manual.\n", _mode.c_str());
-      _mode = STATUS_MANU;
-      saveState();
+      LOG_ERROR("  ✖ no rule defined for mode: %s. Falling back to manual (source=rule-fallback:no-rule).\n", _mode.c_str());
+      setMode(STATUS_MANU, "rule-fallback:no-rule");
     }
   }
 }
@@ -177,7 +185,7 @@ bool OperationModeNode::applyProperty(const String &property, const String &valu
 
   if (property.equalsIgnoreCase("mode")) {
     LOG_INFO("  ✔ set operational mode: %s\n", value.c_str());
-    retval = this->setMode(value);
+    retval = this->setMode(value, "ha:command");
   } else if (property.equalsIgnoreCase("hysteresis")) {
     LOG_INFO("  ✔ hysteresis: %s\n", value.c_str());
     float newValue;
@@ -282,6 +290,8 @@ void OperationModeNode::loadState() {
   if (savedMode == STATUS_AUTO || savedMode == STATUS_MANU || savedMode == STATUS_BOOST || savedMode == STATUS_TIMER) {
     _mode = savedMode;
   }
+
+  LOG_INFO("✓ Operational mode loaded from persistent storage: %s (source=loadState)\n", _mode.c_str());
 
   _poolMaxTemp = StateManager::loadFloat("poolMaxTemp", 28.5f);
   _solarMinTemp = StateManager::loadFloat("solarMinTemp", 55.0f);

--- a/src/OperationModeNode.hpp
+++ b/src/OperationModeNode.hpp
@@ -34,6 +34,7 @@ public:
   uint32_t getMeasurementInterval() const { return _measurementInterval; }
 
   bool setMode(String mode);
+  bool setMode(String mode, const char *source);
   String getMode() const { return _mode; }
 
   void addRule(Rule *rule);

--- a/src/PoolController.cpp
+++ b/src/PoolController.cpp
@@ -231,7 +231,7 @@ auto PoolControllerContext::initializeController() -> void {
   operationModeNode.begin();
 
   // Load properties into Operation Mode
-  operationModeNode.setMode(ConfigManager::getSettings().opMode.c_str());
+  operationModeNode.setMode(ConfigManager::getSettings().opMode.c_str(), "boot:config");
   operationModeNode.setPoolMaxTemperature(ConfigManager::getSettings().tempMaxPool);
   operationModeNode.setSolarMinTemperature(ConfigManager::getSettings().tempMinSolar);
   operationModeNode.setTemperatureHysteresis(ConfigManager::getSettings().tempHysteresis);
@@ -326,13 +326,13 @@ auto PoolControllerContext::setup() -> void {
         // Cycle operation mode
         const String &currentMode = operationModeNode.getMode();
         if (currentMode == "auto") {
-          operationModeNode.setMode("manu");
+          operationModeNode.setMode("manu", "button:S3/menu");
         } else if (currentMode == "manu") {
-          operationModeNode.setMode("boost");
+          operationModeNode.setMode("boost", "button:S3/menu");
         } else if (currentMode == "boost") {
-          operationModeNode.setMode("timer");
+          operationModeNode.setMode("timer", "button:S3/menu");
         } else {
-          operationModeNode.setMode("auto");
+          operationModeNode.setMode("auto", "button:S3/menu");
         }
         LOG_INFO("→ Mode switched to: %s\n", operationModeNode.getMode().c_str());
         break;

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -772,7 +772,7 @@ void WebPortal::apiSaveConfig() {
     operationModeNode.setMeasurementInterval(ConfigManager::getSettings().loopInterval);
 
     // Propagate changes directly into runtime parameters
-    operationModeNode.setMode(ConfigManager::getSettings().opMode.c_str());
+    operationModeNode.setMode(ConfigManager::getSettings().opMode.c_str(), "web:settings");
     operationModeNode.setPoolMaxTemperature(ConfigManager::getSettings().tempMaxPool);
     operationModeNode.setSolarMinTemperature(ConfigManager::getSettings().tempMinSolar);
     operationModeNode.setTemperatureHysteresis(ConfigManager::getSettings().tempHysteresis);
@@ -844,7 +844,7 @@ void WebPortal::apiSetMode() {
   }
 
   String mode = server_.arg("mode");
-  if (operationModeNode.setMode(mode)) {
+  if (operationModeNode.setMode(mode, "web:apiSetMode")) {
     ConfigManager::getSettings().opMode = mode;
     ConfigManager::save();
     server_.send(200, "application/json", "{\"status\":\"ok\",\"mode\":\"" + mode + "\"}");

--- a/test/native/mocks/OperationModeNode.hpp
+++ b/test/native/mocks/OperationModeNode.hpp
@@ -19,13 +19,23 @@ public:
   void loop() {}
 
   String getMode() const { return String(_mode.c_str()); }
-  bool setMode(String mode) { _mode = mode.c_str(); return true; }
+  bool setMode(String mode) { return setMode(mode, "unspecified"); }
+  bool setMode(String mode, const char *source) {
+    _lastModeSource = source != nullptr ? source : "unspecified";
+    _mode = mode.c_str();
+    return true;
+  }
+  const char *getLastModeSource() const { return _lastModeSource.c_str(); }
 
   Rule *getRule() {
-    if (_mode == "auto") return &_autoRule;
-    if (_mode == "manu") return &_manuRule;
-    if (_mode == "boost") return &_boostRule;
-    if (_mode == "timer") return &_timerRule;
+    if (_mode == "auto")
+      return &_autoRule;
+    if (_mode == "manu")
+      return &_manuRule;
+    if (_mode == "boost")
+      return &_boostRule;
+    if (_mode == "timer")
+      return &_timerRule;
     return nullptr;
   }
 
@@ -48,6 +58,7 @@ public:
 
 private:
   std::string _mode = "auto";
+  std::string _lastModeSource = "";
   TimerSetting _timer;
   unsigned long _measurementInterval = 300;
   RuleAuto _autoRule;

--- a/test/native/tests/test_mqttpublisher.cpp
+++ b/test/native/tests/test_mqttpublisher.cpp
@@ -316,19 +316,68 @@ int run_mqttpublisher_tests() {
     MqttPublisher::handleMqttMessage(const_cast<char *>("homeassistant/select/pool-controller/mode/set"),
       const_cast<char *>("boost"), AsyncMqttClientMessageProperties{0, false, false}, 5, 0, 5);
 
-    // The mode should have been set to "boost"
+    // The mode should have been set to "boost" and tagged with its MQTT source.
     std::string mode = operationModeNode.getMode().c_str();
-    rc = (mode == "boost") ? 0 : 1;
-    if (rc == 0) {
+    int missing = 0;
+    if (mode == "boost") {
       test_pass(__FILE__, __LINE__);
-      passed++;
     } else {
       char msg[64];
       snprintf(msg, sizeof(msg), "Expected mode=boost, got %s", mode.c_str());
       test_fail(__FILE__, __LINE__, msg);
-      failed++;
+      missing++;
     }
-    test_suite_end("MqttPublisher::handle_mode_command", rc == 0 ? 1 : 0, rc != 0 ? 1 : 0);
+    if (strcmp(operationModeNode.getLastModeSource(), "mqtt:mode/set") == 0) {
+      test_pass(__FILE__, __LINE__);
+    } else {
+      test_fail(__FILE__, __LINE__, "Mode source not tagged as mqtt:mode/set");
+      missing++;
+    }
+
+    rc = (missing == 0) ? 0 : 1;
+    if (rc == 0)
+      passed++;
+    else
+      failed++;
+    test_suite_end("MqttPublisher::handle_mode_command", missing == 0 ? 1 : 0, missing);
+  }
+
+  // ── Test: Handle MQTT climate commands with mode source tags ──
+  {
+    test_begin("MqttPublisher", "handle climate mode/preset commands tags source");
+
+    operationModeNode.setMode("auto");
+    AsyncMqttClientMessageProperties props{0, false, false};
+
+    char modeTopic[] = "homeassistant/climate/pool-controller/thermostat/mode/set";
+    char modePayload[] = "heat";
+    MqttPublisher::handleMqttMessage(modeTopic, modePayload, props, strlen(modePayload), 0, strlen(modePayload));
+
+    int missing = 0;
+    if (strcmp(operationModeNode.getLastModeSource(), "mqtt:thermostat/mode") == 0) {
+      test_pass(__FILE__, __LINE__);
+    } else {
+      test_fail(__FILE__, __LINE__, "Climate mode source not tagged as mqtt:thermostat/mode");
+      missing++;
+    }
+
+    char presetTopic[] = "homeassistant/climate/pool-controller/thermostat/preset/set";
+    char presetPayload[] = "schedule";
+    MqttPublisher::handleMqttMessage(presetTopic, presetPayload, props, strlen(presetPayload), 0, strlen(presetPayload));
+
+    if (strcmp(operationModeNode.getLastModeSource(), "mqtt:thermostat/preset") == 0) {
+      test_pass(__FILE__, __LINE__);
+    } else {
+      test_fail(__FILE__, __LINE__, "Climate preset source not tagged as mqtt:thermostat/preset");
+      missing++;
+    }
+
+    rc = (missing == 0) ? 0 : 1;
+    if (rc == 0)
+      passed++;
+    else
+      failed++;
+    test_suite_end("MqttPublisher::handle_climate_mode_sources", missing == 0 ? 1 : 0, missing);
   }
 
   // ── Test: Handle MQTT pump command in manual mode ──


### PR DESCRIPTION
## Summary

- add source-aware operation mode logging for MQTT, web, button, HA, boot, and fallback paths
- log repeated same-mode set requests to expose external command loops
- add native MQTT regression coverage for source tags