### PR TITLE
fix(button): Add ADC filtering and improved debouncing for NORVI front panel buttons

### DIFF
--- a/src/MqttPublisher.cpp
+++ b/src/MqttPublisher.cpp
@@ -1067,7 +1067,7 @@ void MqttPublisher::handleMqttMessage(
       return;
     }
     LOG_INFO("MQTT: Climate preset → pool mode \"%s\"\n", poolMode.c_str());
-    operationModeNode.setMode(poolMode.c_str());
+    operationModeNode.setMode(poolMode.c_str(), "mqtt:thermostat/preset");
     ConfigManager::getSettings().opMode = poolMode;
     ConfigManager::save();
     publishStates();
@@ -1088,7 +1088,7 @@ void MqttPublisher::handleMqttMessage(
       return;
     }
     LOG_INFO("MQTT: Climate mode → pool mode \"%s\"\n", poolMode.c_str());
-    operationModeNode.setMode(poolMode.c_str());
+    operationModeNode.setMode(poolMode.c_str(), "mqtt:thermostat/mode");
     ConfigManager::getSettings().opMode = poolMode;
     ConfigManager::save();
     publishStates();
@@ -1148,7 +1148,7 @@ void MqttPublisher::handleMqttMessage(
       return;
     }
 
-    operationModeNode.setMode(value.c_str());
+    operationModeNode.setMode(value.c_str(), "mqtt:mode/set");
     ConfigManager::getSettings().opMode = value;
     ConfigManager::save();
   } else if (top.endsWith("/pool-max-temp/set")) {

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -49,6 +49,7 @@ NorviButtonHandler::ButtonLongPressCallback NorviButtonHandler::cbButton2Long_ =
 NorviButtonHandler::ButtonLongPressCallback NorviButtonHandler::cbButton3Long_ = nullptr;
 
 uint32_t NorviButtonHandler::pressStartMs_ = 0;
+uint32_t NorviButtonHandler::releasePendingMs_ = 0;
 
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -94,12 +95,35 @@ void NorviButtonHandler::loop() {
   // transition also restarts the stability window, so a single-sample glitch
   // crossing an adjacent range boundary (e.g. 3800 → 3700, delta 100) cannot
   // be accepted immediately — it must hold for the full stability period.
-  if (detectButton(rawAdc) != detectButton(lastFilteredAdc_)) {
+  Button rawButton = detectButton(rawAdc);
+  if (rawButton != detectButton(lastFilteredAdc_)) {
     for (uint8_t i = 0; i < ADC_FILTER_SIZE; i++) {
       adcSamples_[i] = rawAdc;
     }
     adcSampleIndex_ = 0;
     lastStableTime_ = now;
+
+    // Release observation: a confirmed press released into the no-press
+    // range is committed after DEBOUNCE_MS instead of the full stability
+    // window, so rapid consecutive taps are not merged into one press.
+    if (currentButton_ != Button::NONE && rawButton == Button::NONE) {
+      if (releasePendingMs_ == 0) {
+        releasePendingMs_ = now;
+      }
+    } else {
+      releasePendingMs_ = 0;  // back in a button range — not a release
+    }
+  }
+
+  // Commit a confirmed release once it has persisted for the debounce
+  // interval. Runs before the stability gates so it is not delayed by the
+  // press-stability window.
+  if (releasePendingMs_ != 0 && (now - releasePendingMs_ >= DEBOUNCE_MS)) {
+    currentButton_ = Button::NONE;
+    lastChangeMs_ = now;
+    pressStartMs_ = 0;
+    releasePendingMs_ = 0;
+    LOG_DEBUG("Button released: %d\n", static_cast<int>(currentButton_));
   }
 
   // Store sample for filtering

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -35,7 +35,6 @@ uint16_t NorviButtonHandler::lastRaw_ = 0;
 // fast-attack re-initialization — a genuine press/release jumps the
 // window immediately instead of waiting for the average to catch up.
 static constexpr uint8_t ADC_FILTER_SIZE = 5;
-static constexpr uint16_t FAST_ATTACK_DELTA = 300;
 static uint16_t adcSamples_[ADC_FILTER_SIZE] = {0};
 static uint8_t adcSampleIndex_ = 0;
 static uint32_t lastFilteredAdcTime_ = 0;
@@ -84,10 +83,11 @@ void NorviButtonHandler::loop() {
   // Read ADC
   uint16_t rawAdc = analogRead(PIN_BUTTON_ADC);
 
-  // Fast-attack: a large deviation from the filtered value is a genuine
-  // press/release — re-initialize the window so the filter responds within
-  // one sample instead of a full window (fixes short presses < 500ms).
-  if (abs(static_cast<int>(rawAdc) - static_cast<int>(lastFilteredAdc_)) > FAST_ATTACK_DELTA) {
+  // Fast-attack: a genuine press/release changes the button range — even
+  // when the ADC delta is small (no-press 3800 → S3 3700 = 100). Base the
+  // re-initialization on button-range transitions so every valid press is
+  // caught within one sample instead of a full moving-average window.
+  if (detectButton(rawAdc) != detectButton(lastFilteredAdc_)) {
     for (uint8_t i = 0; i < ADC_FILTER_SIZE; i++) {
       adcSamples_[i] = rawAdc;
     }
@@ -230,8 +230,8 @@ float NorviButtonHandler::getLongPressProgress() {
 // ═══════════════════════════════════════════════════════════════════════════
 
 NorviButtonHandler::Button NorviButtonHandler::detectButton(uint16_t raw) {
-  // Use filtered ADC value for detection
-  uint16_t adcValue = lastFilteredAdc_;
+  // Use the supplied ADC value for detection.
+  uint16_t adcValue = raw;
 
   if (adcValue >= THRESH_NO_PRESS) {
     return Button::NONE;

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -164,7 +164,11 @@ void NorviButtonHandler::loop() {
       lastDebugAdc_ = filteredAdc;
     }
     // A pending short press may complete even while the signal changes —
-    // evaluate the debounce on this reading too.
+    // evaluate the debounce on this reading too. A long-press callback may
+    // also be due, so check it first (it consumes the press on success).
+    if (evaluateLongPress(now)) {
+      return;
+    }
     evaluateShortPress(now);
     return;
   }
@@ -182,6 +186,12 @@ void NorviButtonHandler::loop() {
     }
     // Let a pending debounce complete while the ADC re-stabilizes (e.g.
     // after a release) — otherwise a short press never fires its callback.
+    // Evaluate long presses here too: a held button spends most samples in
+    // this wait, and a release at the LONG_PRESS_MS mark must not swallow
+    // the callback (e.g. S3 save-and-reboot after a full 2s hold).
+    if (evaluateLongPress(now)) {
+      return;
+    }
     evaluateShortPress(now);
     return;
   }
@@ -217,29 +227,8 @@ void NorviButtonHandler::loop() {
   }
 
   // ── Long-press detection (fire once after LONG_PRESS_MS) ─────────────
-  if (currentButton_ != Button::NONE && pressStartMs_ > 0 && (now - pressStartMs_ >= LONG_PRESS_MS)) {
-    pressStartMs_ = 0;  // Prevent re-firing
-
-    // Fire long-press callbacks; skip short-press if callback consumed it
-    switch (currentButton_) {
-    case Button::ONE:
-      if (cbButton1Long_ && cbButton1Long_()) {
-        return;
-      }
-      break;
-    case Button::TWO:
-      if (cbButton2Long_ && cbButton2Long_()) {
-        return;
-      }
-      break;
-    case Button::THREE:
-      if (cbButton3Long_ && cbButton3Long_()) {
-        return;
-      }
-      break;
-    default:
-      break;
-    }
+  if (evaluateLongPress(now)) {
+    return;  // Long-press callback consumed the press
   }
 
   // ── Short-press detection ────────────────────────────────────────────
@@ -312,6 +301,36 @@ void NorviButtonHandler::evaluateShortPress(uint32_t now) {
       break;
     }
   }
+}
+
+bool NorviButtonHandler::evaluateLongPress(uint32_t now) {
+  // Fire the long-press callback once after LONG_PRESS_MS.
+  if (currentButton_ != Button::NONE && pressStartMs_ > 0 && (now - pressStartMs_ >= LONG_PRESS_MS)) {
+    pressStartMs_ = 0;  // Prevent re-firing
+
+    // Fire long-press callbacks; report whether the callback consumed the
+    // press (short press must then be skipped).
+    switch (currentButton_) {
+    case Button::ONE:
+      if (cbButton1Long_ && cbButton1Long_()) {
+        return true;
+      }
+      break;
+    case Button::TWO:
+      if (cbButton2Long_ && cbButton2Long_()) {
+        return true;
+      }
+      break;
+    case Button::THREE:
+      if (cbButton3Long_ && cbButton3Long_()) {
+        return true;
+      }
+      break;
+    default:
+      break;
+    }
+  }
+  return false;
 }
 
 }  // namespace PoolController

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -103,15 +103,24 @@ void NorviButtonHandler::loop() {
     adcSampleIndex_ = 0;
     lastStableTime_ = now;
 
+    if (releasePendingMs_ != 0) {
+      // A press transition interrupts a pending release. If the release
+      // already persisted for the debounce interval, commit it so the new
+      // press is tracked as a fresh tap; otherwise treat it as bounce.
+      if (rawButton != Button::NONE && (now - releasePendingMs_ >= DEBOUNCE_MS)) {
+        currentButton_ = Button::NONE;
+        lastChangeMs_ = now;
+        pressStartMs_ = 0;
+        LOG_DEBUG("Button released: %d\n", static_cast<int>(currentButton_));
+      }
+      releasePendingMs_ = 0;
+    }
+
     // Release observation: a confirmed press released into the no-press
     // range is committed after DEBOUNCE_MS instead of the full stability
     // window, so rapid consecutive taps are not merged into one press.
     if (currentButton_ != Button::NONE && rawButton == Button::NONE) {
-      if (releasePendingMs_ == 0) {
-        releasePendingMs_ = now;
-      }
-    } else {
-      releasePendingMs_ = 0;  // back in a button range — not a release
+      releasePendingMs_ = now;
     }
   }
 

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -126,6 +126,9 @@ void NorviButtonHandler::loop() {
         THRESH_BTN3_MAX, THRESH_NO_PRESS);
       lastDebugAdc_ = filteredAdc;
     }
+    // A pending short press may complete even while the signal changes —
+    // evaluate the debounce on this reading too.
+    evaluateShortPress(now);
     return;
   }
 
@@ -140,6 +143,9 @@ void NorviButtonHandler::loop() {
       LOG_DEBUG("ADC UNSTABLE: filtered=%u (waiting for stability)\n", filteredAdc);
       lastDebugAdc_ = filteredAdc;
     }
+    // Let a pending debounce complete while the ADC re-stabilizes (e.g.
+    // after a release) — otherwise a short press never fires its callback.
+    evaluateShortPress(now);
     return;
   }
 
@@ -200,28 +206,10 @@ void NorviButtonHandler::loop() {
   }
 
   // ── Short-press detection ────────────────────────────────────────────
-  // Debounce: only register a change if it persists for DEBOUNCE_MS
-  if (stableButton_ != currentButton_ && (now - lastChangeMs_ >= DEBOUNCE_MS)) {
-    stableButton_ = currentButton_;
-
-    // Fire callback on press (not release)
-    switch (stableButton_) {
-    case Button::ONE:
-      if (cbButton1_)
-        cbButton1_();
-      break;
-    case Button::TWO:
-      if (cbButton2_)
-        cbButton2_();
-      break;
-    case Button::THREE:
-      if (cbButton3_)
-        cbButton3_();
-      break;
-    default:
-      break;
-    }
-  }
+  // Debounce: only register a change if it persists for DEBOUNCE_MS.
+  // Also evaluated on unstable/significant-change readings (see above) so
+  // a release during re-stabilization cannot swallow the callback.
+  evaluateShortPress(now);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -262,6 +250,31 @@ NorviButtonHandler::Button NorviButtonHandler::detectButton(uint16_t raw) {
   }
 
   return Button::NONE;
+}
+
+void NorviButtonHandler::evaluateShortPress(uint32_t now) {
+  // Debounce: only register a change if it persists for DEBOUNCE_MS.
+  if (stableButton_ != currentButton_ && (now - lastChangeMs_ >= DEBOUNCE_MS)) {
+    stableButton_ = currentButton_;
+
+    // Fire callback on press (not release)
+    switch (stableButton_) {
+    case Button::ONE:
+      if (cbButton1_)
+        cbButton1_();
+      break;
+    case Button::TWO:
+      if (cbButton2_)
+        cbButton2_();
+      break;
+    case Button::THREE:
+      if (cbButton3_)
+        cbButton3_();
+      break;
+    default:
+      break;
+    }
+  }
 }
 
 }  // namespace PoolController

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -83,15 +83,23 @@ void NorviButtonHandler::loop() {
   // Read ADC
   uint16_t rawAdc = analogRead(PIN_BUTTON_ADC);
 
+  // Enhanced ADC stability check: only accept values that are stable for 150ms
+  static uint16_t lastStableAdc_ = 0;
+  static uint32_t lastStableTime_ = 0;
+
   // Fast-attack: a genuine press/release changes the button range — even
   // when the ADC delta is small (no-press 3800 → S3 3700 = 100). Base the
   // re-initialization on button-range transitions so every valid press is
-  // caught within one sample instead of a full moving-average window.
+  // caught within one sample instead of a full moving-average window. The
+  // transition also restarts the stability window, so a single-sample glitch
+  // crossing an adjacent range boundary (e.g. 3800 → 3700, delta 100) cannot
+  // be accepted immediately — it must hold for the full stability period.
   if (detectButton(rawAdc) != detectButton(lastFilteredAdc_)) {
     for (uint8_t i = 0; i < ADC_FILTER_SIZE; i++) {
       adcSamples_[i] = rawAdc;
     }
     adcSampleIndex_ = 0;
+    lastStableTime_ = now;
   }
 
   // Store sample for filtering
@@ -106,10 +114,6 @@ void NorviButtonHandler::loop() {
   uint16_t filteredAdc = static_cast<uint16_t>(sum / ADC_FILTER_SIZE);
   lastFilteredAdc_ = filteredAdc;
   lastFilteredAdcTime_ = now;
-
-  // Enhanced ADC stability check: only accept values that are stable for 150ms
-  static uint16_t lastStableAdc_ = 0;
-  static uint32_t lastStableTime_ = 0;
 
   if (abs(static_cast<int>(filteredAdc) - static_cast<int>(lastStableAdc_)) > 100) {
     // Significant change detected - reset stability timer

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -31,8 +31,12 @@ uint32_t NorviButtonHandler::lastChangeMs_ = 0;
 uint32_t NorviButtonHandler::lastSampleMs_ = 0;
 uint16_t NorviButtonHandler::lastRaw_ = 0;
 
-// ADC Filtering: Moving average over 5 samples (250ms window)
-static uint16_t adcSamples_[5] = {0};
+// ADC Filtering: moving average over 5 samples (250ms window) with
+// fast-attack re-initialization — a genuine press/release jumps the
+// window immediately instead of waiting for the average to catch up.
+static constexpr uint8_t ADC_FILTER_SIZE = 5;
+static constexpr uint16_t FAST_ATTACK_DELTA = 300;
+static uint16_t adcSamples_[ADC_FILTER_SIZE] = {0};
 static uint8_t adcSampleIndex_ = 0;
 static uint32_t lastFilteredAdcTime_ = 0;
 static uint16_t lastFilteredAdc_ = 0;
@@ -77,52 +81,59 @@ void NorviButtonHandler::loop() {
   }
   lastSampleMs_ = now;
 
-  // Read ADC and apply moving average filter (5 samples = 250ms window)
+  // Read ADC
   uint16_t rawAdc = analogRead(PIN_BUTTON_ADC);
-  
+
+  // Fast-attack: a large deviation from the filtered value is a genuine
+  // press/release — re-initialize the window so the filter responds within
+  // one sample instead of a full window (fixes short presses < 500ms).
+  if (abs(static_cast<int>(rawAdc) - static_cast<int>(lastFilteredAdc_)) > FAST_ATTACK_DELTA) {
+    for (uint8_t i = 0; i < ADC_FILTER_SIZE; i++) {
+      adcSamples_[i] = rawAdc;
+    }
+    adcSampleIndex_ = 0;
+  }
+
   // Store sample for filtering
   adcSamples_[adcSampleIndex_] = rawAdc;
-  adcSampleIndex_ = (adcSampleIndex_ + 1) % 5;
-  
+  adcSampleIndex_ = (adcSampleIndex_ + 1) % ADC_FILTER_SIZE;
+
   // Calculate moving average
   uint32_t sum = 0;
-  for (uint8_t i = 0; i < 5; i++) {
+  for (uint8_t i = 0; i < ADC_FILTER_SIZE; i++) {
     sum += adcSamples_[i];
   }
-  uint16_t filteredAdc = static_cast<uint16_t>(sum / 5);
+  uint16_t filteredAdc = static_cast<uint16_t>(sum / ADC_FILTER_SIZE);
   lastFilteredAdc_ = filteredAdc;
   lastFilteredAdcTime_ = now;
-  
+
   // Enhanced ADC stability check: only accept values that are stable for 150ms
   static uint16_t lastStableAdc_ = 0;
   static uint32_t lastStableTime_ = 0;
-  
+
   if (abs(static_cast<int>(filteredAdc) - static_cast<int>(lastStableAdc_)) > 100) {
     // Significant change detected - reset stability timer
     lastStableAdc_ = filteredAdc;
     lastStableTime_ = now;
     lastRaw_ = filteredAdc;
     Button detected = detectButton(filteredAdc);
-    
+
     // Debug logging for ADC changes
     static uint16_t lastDebugAdc_ = 0xFFFF;
     if (abs(static_cast<int>(filteredAdc) - static_cast<int>(lastDebugAdc_)) > 100) {
-      LOG_DEBUG("ADC: raw=%u filtered=%u → %d | THRESH: BTN1=%u-%u BTN2=%u-%u BTN3=%u-%u NO_PRESS=%u\n",
-        rawAdc, filteredAdc, static_cast<int>(detected),
-        THRESH_BTN1_MIN, THRESH_BTN1_MAX,
-        THRESH_BTN2_MIN, THRESH_BTN2_MAX,
-        THRESH_BTN3_MIN, THRESH_BTN3_MAX,
-        THRESH_NO_PRESS);
+      LOG_DEBUG("ADC: raw=%u filtered=%u → %d | THRESH: BTN1=%u-%u BTN2=%u-%u BTN3=%u-%u NO_PRESS=%u\n", rawAdc, filteredAdc,
+        static_cast<int>(detected), THRESH_BTN1_MIN, THRESH_BTN1_MAX, THRESH_BTN2_MIN, THRESH_BTN2_MAX, THRESH_BTN3_MIN,
+        THRESH_BTN3_MAX, THRESH_NO_PRESS);
       lastDebugAdc_ = filteredAdc;
     }
     return;
   }
-  
+
   if (now - lastStableTime_ < 150) {
     // Not stable yet - ignore this reading
     lastRaw_ = filteredAdc;
     Button detected = Button::NONE;
-    
+
     // Debug logging for unstable ADC
     static uint16_t lastDebugAdc_ = 0xFFFF;
     if (abs(static_cast<int>(filteredAdc) - static_cast<int>(lastDebugAdc_)) > 100) {
@@ -131,7 +142,7 @@ void NorviButtonHandler::loop() {
     }
     return;
   }
-  
+
   // ADC is stable - use filtered value
   lastStableAdc_ = filteredAdc;
   lastStableTime_ = now;
@@ -141,12 +152,9 @@ void NorviButtonHandler::loop() {
   // Enhanced debug logging for ADC changes
   static uint16_t lastDebugAdc_ = 0xFFFF;
   if (abs(static_cast<int>(filteredAdc) - static_cast<int>(lastDebugAdc_)) > 100) {
-    LOG_DEBUG("ADC: raw=%u filtered=%u → %d | THRESH: BTN1=%u-%u BTN2=%u-%u BTN3=%u-%u NO_PRESS=%u\n",
-      rawAdc, filteredAdc, static_cast<int>(detected),
-      THRESH_BTN1_MIN, THRESH_BTN1_MAX,
-      THRESH_BTN2_MIN, THRESH_BTN2_MAX,
-      THRESH_BTN3_MIN, THRESH_BTN3_MAX,
-      THRESH_NO_PRESS);
+    LOG_DEBUG("ADC: raw=%u filtered=%u → %d | THRESH: BTN1=%u-%u BTN2=%u-%u BTN3=%u-%u NO_PRESS=%u\n", rawAdc, filteredAdc,
+      static_cast<int>(detected), THRESH_BTN1_MIN, THRESH_BTN1_MAX, THRESH_BTN2_MIN, THRESH_BTN2_MAX, THRESH_BTN3_MIN,
+      THRESH_BTN3_MAX, THRESH_NO_PRESS);
     lastDebugAdc_ = filteredAdc;
   }
 
@@ -236,7 +244,7 @@ float NorviButtonHandler::getLongPressProgress() {
 NorviButtonHandler::Button NorviButtonHandler::detectButton(uint16_t raw) {
   // Use filtered ADC value for detection
   uint16_t adcValue = lastFilteredAdc_;
-  
+
   if (adcValue >= THRESH_NO_PRESS) {
     return Button::NONE;
   }

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -31,6 +31,12 @@ uint32_t NorviButtonHandler::lastChangeMs_ = 0;
 uint32_t NorviButtonHandler::lastSampleMs_ = 0;
 uint16_t NorviButtonHandler::lastRaw_ = 0;
 
+// ADC Filtering: Moving average over 5 samples (250ms window)
+static uint16_t adcSamples_[5] = {0};
+static uint8_t adcSampleIndex_ = 0;
+static uint32_t lastFilteredAdcTime_ = 0;
+static uint16_t lastFilteredAdc_ = 0;
+
 NorviButtonHandler::ButtonCallback NorviButtonHandler::cbButton1_ = nullptr;
 NorviButtonHandler::ButtonCallback NorviButtonHandler::cbButton2_ = nullptr;
 NorviButtonHandler::ButtonCallback NorviButtonHandler::cbButton3_ = nullptr;
@@ -71,15 +77,77 @@ void NorviButtonHandler::loop() {
   }
   lastSampleMs_ = now;
 
-  // Read ADC
-  lastRaw_ = analogRead(PIN_BUTTON_ADC);
-  Button detected = detectButton(lastRaw_);
+  // Read ADC and apply moving average filter (5 samples = 250ms window)
+  uint16_t rawAdc = analogRead(PIN_BUTTON_ADC);
+  
+  // Store sample for filtering
+  adcSamples_[adcSampleIndex_] = rawAdc;
+  adcSampleIndex_ = (adcSampleIndex_ + 1) % 5;
+  
+  // Calculate moving average
+  uint32_t sum = 0;
+  for (uint8_t i = 0; i < 5; i++) {
+    sum += adcSamples_[i];
+  }
+  uint16_t filteredAdc = static_cast<uint16_t>(sum / 5);
+  lastFilteredAdc_ = filteredAdc;
+  lastFilteredAdcTime_ = now;
+  
+  // Enhanced ADC stability check: only accept values that are stable for 150ms
+  static uint16_t lastStableAdc_ = 0;
+  static uint32_t lastStableTime_ = 0;
+  
+  if (abs(static_cast<int>(filteredAdc) - static_cast<int>(lastStableAdc_)) > 100) {
+    // Significant change detected - reset stability timer
+    lastStableAdc_ = filteredAdc;
+    lastStableTime_ = now;
+    lastRaw_ = filteredAdc;
+    Button detected = detectButton(filteredAdc);
+    
+    // Debug logging for ADC changes
+    static uint16_t lastDebugAdc_ = 0xFFFF;
+    if (abs(static_cast<int>(filteredAdc) - static_cast<int>(lastDebugAdc_)) > 100) {
+      LOG_DEBUG("ADC: raw=%u filtered=%u → %d | THRESH: BTN1=%u-%u BTN2=%u-%u BTN3=%u-%u NO_PRESS=%u\n",
+        rawAdc, filteredAdc, static_cast<int>(detected),
+        THRESH_BTN1_MIN, THRESH_BTN1_MAX,
+        THRESH_BTN2_MIN, THRESH_BTN2_MAX,
+        THRESH_BTN3_MIN, THRESH_BTN3_MAX,
+        THRESH_NO_PRESS);
+      lastDebugAdc_ = filteredAdc;
+    }
+    return;
+  }
+  
+  if (now - lastStableTime_ < 150) {
+    // Not stable yet - ignore this reading
+    lastRaw_ = filteredAdc;
+    Button detected = Button::NONE;
+    
+    // Debug logging for unstable ADC
+    static uint16_t lastDebugAdc_ = 0xFFFF;
+    if (abs(static_cast<int>(filteredAdc) - static_cast<int>(lastDebugAdc_)) > 100) {
+      LOG_DEBUG("ADC UNSTABLE: filtered=%u (waiting for stability)\n", filteredAdc);
+      lastDebugAdc_ = filteredAdc;
+    }
+    return;
+  }
+  
+  // ADC is stable - use filtered value
+  lastStableAdc_ = filteredAdc;
+  lastStableTime_ = now;
+  lastRaw_ = filteredAdc;
+  Button detected = detectButton(filteredAdc);
 
-  // Add debug logging for ADC changes
+  // Enhanced debug logging for ADC changes
   static uint16_t lastDebugAdc_ = 0xFFFF;
-  if (abs(static_cast<int>(lastRaw_) - static_cast<int>(lastDebugAdc_)) > 50) {
-    LOG_DEBUG("ADC: %u → %d\n", lastDebugAdc_, static_cast<int>(detected));
-    lastDebugAdc_ = lastRaw_;
+  if (abs(static_cast<int>(filteredAdc) - static_cast<int>(lastDebugAdc_)) > 100) {
+    LOG_DEBUG("ADC: raw=%u filtered=%u → %d | THRESH: BTN1=%u-%u BTN2=%u-%u BTN3=%u-%u NO_PRESS=%u\n",
+      rawAdc, filteredAdc, static_cast<int>(detected),
+      THRESH_BTN1_MIN, THRESH_BTN1_MAX,
+      THRESH_BTN2_MIN, THRESH_BTN2_MAX,
+      THRESH_BTN3_MIN, THRESH_BTN3_MAX,
+      THRESH_NO_PRESS);
+    lastDebugAdc_ = filteredAdc;
   }
 
   // ── Press start tracking ─────────────────────────────────────────────
@@ -89,8 +157,10 @@ void NorviButtonHandler::loop() {
 
     if (detected != Button::NONE) {
       pressStartMs_ = now;  // Button was just pressed
+      LOG_DEBUG("Button pressed: %d\n", static_cast<int>(detected));
     } else {
       pressStartMs_ = 0;  // Button released
+      LOG_DEBUG("Button released: %d\n", static_cast<int>(currentButton_));
     }
     return;
   }
@@ -164,19 +234,22 @@ float NorviButtonHandler::getLongPressProgress() {
 // ═══════════════════════════════════════════════════════════════════════════
 
 NorviButtonHandler::Button NorviButtonHandler::detectButton(uint16_t raw) {
-  if (raw >= THRESH_NO_PRESS) {
+  // Use filtered ADC value for detection
+  uint16_t adcValue = lastFilteredAdc_;
+  
+  if (adcValue >= THRESH_NO_PRESS) {
     return Button::NONE;
   }
 
-  if (raw >= THRESH_BTN1_MIN && raw <= THRESH_BTN1_MAX) {
+  if (adcValue >= THRESH_BTN1_MIN && adcValue <= THRESH_BTN1_MAX) {
     return Button::ONE;
   }
 
-  if (raw >= THRESH_BTN2_MIN && raw <= THRESH_BTN2_MAX) {
+  if (adcValue >= THRESH_BTN2_MIN && adcValue <= THRESH_BTN2_MAX) {
     return Button::TWO;
   }
 
-  if (raw >= THRESH_BTN3_MIN && raw <= THRESH_BTN3_MAX) {
+  if (adcValue >= THRESH_BTN3_MIN && adcValue <= THRESH_BTN3_MAX) {
     return Button::THREE;
   }
 

--- a/src/NorviButtonHandler.hpp
+++ b/src/NorviButtonHandler.hpp
@@ -125,6 +125,10 @@ private:
    */
   static void evaluateShortPress(uint32_t now);
 
+  /// Fires the long-press callback once after LONG_PRESS_MS.
+  /// @return true if the callback consumed the press (skip short press).
+  static bool evaluateLongPress(uint32_t now);
+
   /// Debounce interval (ms) — ignores samples within this window.
   static constexpr uint32_t DEBOUNCE_MS{80};
 

--- a/src/NorviButtonHandler.hpp
+++ b/src/NorviButtonHandler.hpp
@@ -117,6 +117,14 @@ private:
    */
   static Button detectButton(uint16_t raw);
 
+  /**
+   * @brief Fire the short-press callback once the debounce interval elapsed.
+   * Runs on every sample once a press is pending — including while the ADC
+   * re-stabilizes after a release — so a short press is not swallowed by
+   * the release stabilization path.
+   */
+  static void evaluateShortPress(uint32_t now);
+
   /// Debounce interval (ms) — ignores samples within this window.
   static constexpr uint32_t DEBOUNCE_MS{80};
 

--- a/src/NorviButtonHandler.hpp
+++ b/src/NorviButtonHandler.hpp
@@ -162,6 +162,11 @@ private:
   /// Timestamp when the current button was first pressed.
   static uint32_t pressStartMs_;
 
+  /// Timestamp when a confirmed press was first observed released (ms).
+  /// Non-zero while the release is being debounced; the release is
+  /// committed to `currentButton_` after DEBOUNCE_MS.
+  static uint32_t releasePendingMs_;
+
   // ── ADC thresholds (12-bit, 0–4095) ──────────────────────────────────
   // These are typical ranges for the NORVI AE01-R resistor ladder.
   // Adjust if needed based on serial debug output.

--- a/src/OperationModeNode.cpp
+++ b/src/OperationModeNode.cpp
@@ -113,22 +113,31 @@ Rule *OperationModeNode::getRule() {
 }
 
 bool OperationModeNode::setMode(String mode) {
+  return setMode(mode, "unspecified");
+}
+
+bool OperationModeNode::setMode(String mode, const char *source) {
+  if (source == nullptr) {
+    source = "unspecified";
+  }
   if (mode.equals(STATUS_AUTO) || mode.equals(STATUS_MANU) || mode.equals(STATUS_BOOST) || mode.equals(STATUS_TIMER)) {
-    // Reset temperature-based runtime extension on mode change
-    for (auto &rule : _ruleVec) {
-      rule->resetTemperatureExtension();
-    }
-    // Curated log event for MQTT event entity — only on actual mode change
     if (!_mode.equals(mode)) {
-      PoolController::LogCapture::logEvent("MODE_CHANGED", "Mode switched to %s", mode.c_str());
+      // Reset temperature-based runtime extension on mode change
+      for (auto &rule : _ruleVec) {
+        rule->resetTemperatureExtension();
+      }
+      PoolController::LogCapture::logEvent("MODE_CHANGED", "Mode changed %s -> %s (source=%s, persist=%s)", _mode.c_str(),
+        mode.c_str(), source, _suppressPersist ? "no" : "yes");
+      _mode = mode;
+      LOG_DEBUG("set mode: %s (source=%s)\n", _mode.c_str(), source);
+      if (!_suppressPersist)
+        saveState();
+    } else {
+      LOG_INFO("Mode set requested: %s -> %s (source=%s, changed=no, persist=no)\n", _mode.c_str(), mode.c_str(), source);
     }
-    _mode = mode;
-    LOG_DEBUG("set mode: %s\n", _mode.c_str());
-    if (!_suppressPersist)
-      saveState();
     return true;
   } else {
-    LOG_ERROR("✖ UNDEFINED Mode: %s. Current unchanged mode: %s\n", mode.c_str(), _mode.c_str());
+    LOG_ERROR("✖ UNDEFINED Mode: %s. Current unchanged mode: %s (source=%s)\n", mode.c_str(), _mode.c_str(), source);
     return false;
   }
 }
@@ -158,9 +167,8 @@ void OperationModeNode::loop() {
     if (rule != nullptr) {
       rule->loop();
     } else {
-      LOG_ERROR("  ✖ no rule defined for mode: %s. Falling back to manual.\n", _mode.c_str());
-      _mode = STATUS_MANU;
-      saveState();
+      LOG_ERROR("  ✖ no rule defined for mode: %s. Falling back to manual (source=rule-fallback:no-rule).\n", _mode.c_str());
+      setMode(STATUS_MANU, "rule-fallback:no-rule");
     }
   }
 }
@@ -177,7 +185,7 @@ bool OperationModeNode::applyProperty(const String &property, const String &valu
 
   if (property.equalsIgnoreCase("mode")) {
     LOG_INFO("  ✔ set operational mode: %s\n", value.c_str());
-    retval = this->setMode(value);
+    retval = this->setMode(value, "ha:command");
   } else if (property.equalsIgnoreCase("hysteresis")) {
     LOG_INFO("  ✔ hysteresis: %s\n", value.c_str());
     float newValue;
@@ -282,6 +290,8 @@ void OperationModeNode::loadState() {
   if (savedMode == STATUS_AUTO || savedMode == STATUS_MANU || savedMode == STATUS_BOOST || savedMode == STATUS_TIMER) {
     _mode = savedMode;
   }
+
+  LOG_INFO("✓ Operational mode loaded from persistent storage: %s (source=loadState)\n", _mode.c_str());
 
   _poolMaxTemp = StateManager::loadFloat("poolMaxTemp", 28.5f);
   _solarMinTemp = StateManager::loadFloat("solarMinTemp", 55.0f);

--- a/src/OperationModeNode.hpp
+++ b/src/OperationModeNode.hpp
@@ -34,6 +34,7 @@ public:
   uint32_t getMeasurementInterval() const { return _measurementInterval; }
 
   bool setMode(String mode);
+  bool setMode(String mode, const char *source);
   String getMode() const { return _mode; }
 
   void addRule(Rule *rule);

--- a/src/PoolController.cpp
+++ b/src/PoolController.cpp
@@ -231,7 +231,7 @@ auto PoolControllerContext::initializeController() -> void {
   operationModeNode.begin();
 
   // Load properties into Operation Mode
-  operationModeNode.setMode(ConfigManager::getSettings().opMode.c_str());
+  operationModeNode.setMode(ConfigManager::getSettings().opMode.c_str(), "boot:config");
   operationModeNode.setPoolMaxTemperature(ConfigManager::getSettings().tempMaxPool);
   operationModeNode.setSolarMinTemperature(ConfigManager::getSettings().tempMinSolar);
   operationModeNode.setTemperatureHysteresis(ConfigManager::getSettings().tempHysteresis);
@@ -326,13 +326,13 @@ auto PoolControllerContext::setup() -> void {
         // Cycle operation mode
         const String &currentMode = operationModeNode.getMode();
         if (currentMode == "auto") {
-          operationModeNode.setMode("manu");
+          operationModeNode.setMode("manu", "button:S3/menu");
         } else if (currentMode == "manu") {
-          operationModeNode.setMode("boost");
+          operationModeNode.setMode("boost", "button:S3/menu");
         } else if (currentMode == "boost") {
-          operationModeNode.setMode("timer");
+          operationModeNode.setMode("timer", "button:S3/menu");
         } else {
-          operationModeNode.setMode("auto");
+          operationModeNode.setMode("auto", "button:S3/menu");
         }
         LOG_INFO("→ Mode switched to: %s\n", operationModeNode.getMode().c_str());
         break;

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -772,7 +772,7 @@ void WebPortal::apiSaveConfig() {
     operationModeNode.setMeasurementInterval(ConfigManager::getSettings().loopInterval);
 
     // Propagate changes directly into runtime parameters
-    operationModeNode.setMode(ConfigManager::getSettings().opMode.c_str());
+    operationModeNode.setMode(ConfigManager::getSettings().opMode.c_str(), "web:settings");
     operationModeNode.setPoolMaxTemperature(ConfigManager::getSettings().tempMaxPool);
     operationModeNode.setSolarMinTemperature(ConfigManager::getSettings().tempMinSolar);
     operationModeNode.setTemperatureHysteresis(ConfigManager::getSettings().tempHysteresis);
@@ -844,7 +844,7 @@ void WebPortal::apiSetMode() {
   }
 
   String mode = server_.arg("mode");
-  if (operationModeNode.setMode(mode)) {
+  if (operationModeNode.setMode(mode, "web:apiSetMode")) {
     ConfigManager::getSettings().opMode = mode;
     ConfigManager::save();
     server_.send(200, "application/json", "{\"status\":\"ok\",\"mode\":\"" + mode + "\"}");

--- a/test/native/mocks/OperationModeNode.hpp
+++ b/test/native/mocks/OperationModeNode.hpp
@@ -19,13 +19,23 @@ public:
   void loop() {}
 
   String getMode() const { return String(_mode.c_str()); }
-  bool setMode(String mode) { _mode = mode.c_str(); return true; }
+  bool setMode(String mode) { return setMode(mode, "unspecified"); }
+  bool setMode(String mode, const char *source) {
+    _lastModeSource = source != nullptr ? source : "unspecified";
+    _mode = mode.c_str();
+    return true;
+  }
+  const char *getLastModeSource() const { return _lastModeSource.c_str(); }
 
   Rule *getRule() {
-    if (_mode == "auto") return &_autoRule;
-    if (_mode == "manu") return &_manuRule;
-    if (_mode == "boost") return &_boostRule;
-    if (_mode == "timer") return &_timerRule;
+    if (_mode == "auto")
+      return &_autoRule;
+    if (_mode == "manu")
+      return &_manuRule;
+    if (_mode == "boost")
+      return &_boostRule;
+    if (_mode == "timer")
+      return &_timerRule;
     return nullptr;
   }
 
@@ -48,6 +58,7 @@ public:
 
 private:
   std::string _mode = "auto";
+  std::string _lastModeSource = "";
   TimerSetting _timer;
   unsigned long _measurementInterval = 300;
   RuleAuto _autoRule;

--- a/test/native/tests/test_mqttpublisher.cpp
+++ b/test/native/tests/test_mqttpublisher.cpp
@@ -316,19 +316,68 @@ int run_mqttpublisher_tests() {
     MqttPublisher::handleMqttMessage(const_cast<char *>("homeassistant/select/pool-controller/mode/set"),
       const_cast<char *>("boost"), AsyncMqttClientMessageProperties{0, false, false}, 5, 0, 5);
 
-    // The mode should have been set to "boost"
+    // The mode should have been set to "boost" and tagged with its MQTT source.
     std::string mode = operationModeNode.getMode().c_str();
-    rc = (mode == "boost") ? 0 : 1;
-    if (rc == 0) {
+    int missing = 0;
+    if (mode == "boost") {
       test_pass(__FILE__, __LINE__);
-      passed++;
     } else {
       char msg[64];
       snprintf(msg, sizeof(msg), "Expected mode=boost, got %s", mode.c_str());
       test_fail(__FILE__, __LINE__, msg);
-      failed++;
+      missing++;
     }
-    test_suite_end("MqttPublisher::handle_mode_command", rc == 0 ? 1 : 0, rc != 0 ? 1 : 0);
+    if (strcmp(operationModeNode.getLastModeSource(), "mqtt:mode/set") == 0) {
+      test_pass(__FILE__, __LINE__);
+    } else {
+      test_fail(__FILE__, __LINE__, "Mode source not tagged as mqtt:mode/set");
+      missing++;
+    }
+
+    rc = (missing == 0) ? 0 : 1;
+    if (rc == 0)
+      passed++;
+    else
+      failed++;
+    test_suite_end("MqttPublisher::handle_mode_command", missing == 0 ? 1 : 0, missing);
+  }
+
+  // ── Test: Handle MQTT climate commands with mode source tags ──
+  {
+    test_begin("MqttPublisher", "handle climate mode/preset commands tags source");
+
+    operationModeNode.setMode("auto");
+    AsyncMqttClientMessageProperties props{0, false, false};
+
+    char modeTopic[] = "homeassistant/climate/pool-controller/thermostat/mode/set";
+    char modePayload[] = "heat";
+    MqttPublisher::handleMqttMessage(modeTopic, modePayload, props, strlen(modePayload), 0, strlen(modePayload));
+
+    int missing = 0;
+    if (strcmp(operationModeNode.getLastModeSource(), "mqtt:thermostat/mode") == 0) {
+      test_pass(__FILE__, __LINE__);
+    } else {
+      test_fail(__FILE__, __LINE__, "Climate mode source not tagged as mqtt:thermostat/mode");
+      missing++;
+    }
+
+    char presetTopic[] = "homeassistant/climate/pool-controller/thermostat/preset/set";
+    char presetPayload[] = "schedule";
+    MqttPublisher::handleMqttMessage(presetTopic, presetPayload, props, strlen(presetPayload), 0, strlen(presetPayload));
+
+    if (strcmp(operationModeNode.getLastModeSource(), "mqtt:thermostat/preset") == 0) {
+      test_pass(__FILE__, __LINE__);
+    } else {
+      test_fail(__FILE__, __LINE__, "Climate preset source not tagged as mqtt:thermostat/preset");
+      missing++;
+    }
+
+    rc = (missing == 0) ? 0 : 1;
+    if (rc == 0)
+      passed++;
+    else
+      failed++;
+    test_suite_end("MqttPublisher::handle_climate_mode_sources", missing == 0 ? 1 : 0, missing);
   }
 
   // ── Test: Handle MQTT pump command in manual mode ──


### PR DESCRIPTION
## Summary
This PR fixes the issue where the S3 button was reported as pressed despite no physical interaction, causing constant operation mode and screen changes.

## Root Cause
The NORVI AE01-R front panel buttons share a single ADC input (GPIO32) which is susceptible to EMI/RFI interference. The original firmware had no ADC filtering or proper debouncing, leading to false button detections.

## Changes
- **ADC Filtering**: Added moving average filter over 5 samples (250ms window) to reduce noise
- **Enhanced Debouncing**: Implemented 150ms stability check before accepting button state changes
- **Debug Logging**: Enhanced ADC logging with raw/filtered value comparison and threshold information
- **Stability**: Prevents false button detection from electrical interference

## Testing
- Firmware will be deployed via OTA to pool-controller.local
- Observation over night to verify stable operation
- ADC values will be logged for analysis

## Related Issue
Fixes the reported issue where operation modes and screens changed constantly without user interaction.

---
**Note**: This is a minimal fix focused on the root cause. Hardware improvements (adding capacitors, checking solder joints) can be considered if this doesn't fully resolve the issue.