### PR TITLE
feat(system): log concrete reason when entering safe mode

### DIFF
--- a/src/DegradationManager.cpp
+++ b/src/DegradationManager.cpp
@@ -169,7 +169,9 @@ void DegradationManager::onTransition() {
       if (!NetworkManager::isWiFiConnected()) {
         LOG_ERROR("    - WiFi/MQTT disconnected\n");
       }
-      if (getTimeDegradation() == TimeDegradation::RED) {
+      // NTP loss while WiFi is down is a consequence, not an independent
+      // failure — mirror the counting logic in evaluateLevel().
+      if (NetworkManager::isWiFiConnected() && getTimeDegradation() == TimeDegradation::RED) {
         LOG_ERROR("    - NTP time sync lost\n");
       }
       if (sensorsEverReported_ && !(poolSensorOk_ && solarSensorOk_)) {

--- a/src/DegradationManager.cpp
+++ b/src/DegradationManager.cpp
@@ -158,7 +158,25 @@ void DegradationManager::onTransition() {
     break;
 
   case DegradationLevel::CRITICAL:
-    LOG_ERROR("✖ CRITICAL: Multiple system failures detected!\n");
+    // Log the concrete reason for entering safe mode. Priority mirrors
+    // evaluateLevel(): forced (boot-loop) > low memory > multiple failures.
+    if (forcedSafeMode_) {
+      LOG_ERROR("✖ SAFE MODE — reason: boot-loop detected (safe mode forced)\n");
+    } else if (!SystemMonitor::isHealthy()) {
+      LOG_ERROR("✖ SAFE MODE — reason: critically low free heap (%.1f KB)\n",
+                ESP.getFreeHeap() / 1024.0f);
+    } else {
+      LOG_ERROR("✖ SAFE MODE — reason: multiple concurrent failures\n");
+      if (!NetworkManager::isWiFiConnected()) {
+        LOG_ERROR("    - WiFi/MQTT disconnected\n");
+      }
+      if (getTimeDegradation() == TimeDegradation::RED) {
+        LOG_ERROR("    - NTP time sync lost\n");
+      }
+      if (sensorsEverReported_ && !(poolSensorOk_ && solarSensorOk_)) {
+        LOG_ERROR("    - temperature sensor fault\n");
+      }
+    }
     LOG_ERROR("  Entering safe mode — all relays off\n");
     // De-energize both relays immediately (P1 review fix)
     poolPumpNode.setSwitch(false);

--- a/src/DegradationManager.cpp
+++ b/src/DegradationManager.cpp
@@ -163,8 +163,7 @@ void DegradationManager::onTransition() {
     if (forcedSafeMode_) {
       LOG_ERROR("✖ SAFE MODE — reason: boot-loop detected (safe mode forced)\n");
     } else if (!SystemMonitor::isHealthy()) {
-      LOG_ERROR("✖ SAFE MODE — reason: critically low free heap (%.1f KB)\n",
-                ESP.getFreeHeap() / 1024.0f);
+      LOG_ERROR("✖ SAFE MODE — reason: critically low free heap (%.1f KB)\n", ESP.getFreeHeap() / 1024.0f);
     } else {
       LOG_ERROR("✖ SAFE MODE — reason: multiple concurrent failures\n");
       if (!NetworkManager::isWiFiConnected()) {


### PR DESCRIPTION
## What

When the controller enters safe mode (CRITICAL degradation), the log now states the concrete reason instead of the generic "Multiple system failures detected" message.

## Reason sources

1. **Boot-loop detected** (forced safe mode via `forceSafeMode()`)
2. **Critically low free heap** — logs current value in KB
3. **Multiple concurrent failures** — lists the failing subsystems (WiFi/MQTT, NTP time, temperature sensor)

Priority mirrors the decision logic in `evaluateLevel()`. No API changes; native mocks/tests unaffected.

## Verification

- Build `pio run -e norvi_ae01_r`: SUCCESS (RAM 32.1 %, Flash 96.8 %)