### PR TITLE
fix(button): stop phantom NORVI operation-mode switches

### DIFF
--- a/data/web/app.js
+++ b/data/web/app.js
@@ -589,6 +589,13 @@ async function saveControllerSettings() {
   const circFactor = document.getElementById('tempCircFactor').value;
   const circMaxRuntime = document.getElementById('tempCircMaxRuntime').value;
   const tz = document.getElementById('timezone').value;
+  const btn1Min = document.getElementById('btn1Min').value;
+  const btn1Max = document.getElementById('btn1Max').value;
+  const btn2Min = document.getElementById('btn2Min').value;
+  const btn2Max = document.getElementById('btn2Max').value;
+  const btn3Min = document.getElementById('btn3Min').value;
+  const btn3Max = document.getElementById('btn3Max').value;
+  const btnNoPress = document.getElementById('btnNoPress').value;
 
   // Validate time fields included alongside pool fields
   const green = parseInt(document.getElementById('timeLossGreen').value, 10);
@@ -608,7 +615,7 @@ async function saveControllerSettings() {
   const res = await fetch('/api/config', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: 'type=settings&mode=' + mode + '&interval=' + interval + '&max_pool=' + maxPool + '&min_solar=' + minSolar + '&hysteresis=' + hysteresis + '&circ_threshold=' + circThreshold + '&circ_factor=' + circFactor + '&circ_max_runtime=' + circMaxRuntime + '&timezone=' + tz + '&green=' + green + '&red=' + red + timerParams() + '&ntp_server=' + ntpServer
+    body: 'type=settings&mode=' + mode + '&interval=' + interval + '&max_pool=' + maxPool + '&min_solar=' + minSolar + '&hysteresis=' + hysteresis + '&circ_threshold=' + circThreshold + '&circ_factor=' + circFactor + '&circ_max_runtime=' + circMaxRuntime + '&timezone=' + tz + '&green=' + green + '&red=' + red + timerParams() + '&ntp_server=' + ntpServer + '&btn1_min=' + btn1Min + '&btn1_max=' + btn1Max + '&btn2_min=' + btn2Min + '&btn2_max=' + btn2Max + '&btn3_min=' + btn3Min + '&btn3_max=' + btn3Max + '&btn_no_press=' + btnNoPress
   });
   if (res.status === 200) {
     document.getElementById('poolThreshold').textContent = 'max ' + parseFloat(maxPool).toFixed(1) + '°C';
@@ -729,6 +736,13 @@ async function loadConfig() {
     document.getElementById('ntpServer').value = data.ntp.server;
     document.getElementById('timeLossGreen').value = data.settings.time_loss_green_hours;
     document.getElementById('timeLossRed').value = data.settings.time_loss_red_hours;
+    document.getElementById('btn1Min').value = data.settings.btn1_min;
+    document.getElementById('btn1Max').value = data.settings.btn1_max;
+    document.getElementById('btn2Min').value = data.settings.btn2_min;
+    document.getElementById('btn2Max').value = data.settings.btn2_max;
+    document.getElementById('btn3Min').value = data.settings.btn3_min;
+    document.getElementById('btn3Max').value = data.settings.btn3_max;
+    document.getElementById('btnNoPress').value = data.settings.btn_no_press;
     const pad2 = (n) => n.toString().padStart(2, '0');
     document.getElementById('timerStart').value = pad2(data.settings.timer_start_hour) + ':' + pad2(data.settings.timer_start_min);
     document.getElementById('timerEnd').value = pad2(data.settings.timer_end_hour) + ':' + pad2(data.settings.timer_end_min);

--- a/data/web/app.js
+++ b/data/web/app.js
@@ -592,6 +592,12 @@ function validateSettings() {
     alert('Button ADC ranges must not overlap.');
     return false;
   }
+  // No-press threshold must sit above every button range, otherwise
+  // detectButton() checks THRESH_NO_PRESS first and masks those readings as NONE.
+  if (btnVal('btnNoPress') <= b3Max) {
+    alert('No-Press Threshold must be above all button ranges.');
+    return false;
+  }
   return true;
 }
 

--- a/data/web/app.js
+++ b/data/web/app.js
@@ -553,6 +553,13 @@ function validateSettings() {
     { id: 'tempCircThreshold',  name: 'Circ. Temp Threshold',   min: 0,   max: 40,   type: 'float' },
     { id: 'tempCircFactor',     name: 'Circ. Temp Factor',      min: 0,   max: 120,  type: 'int' },
     { id: 'tempCircMaxRuntime', name: 'Circ. Max Runtime',      min: 60,  max: 1440, type: 'int' },
+    { id: 'btn1Min',    name: 'Button 1 Min ADC',    min: 0, max: 4095, type: 'int' },
+    { id: 'btn1Max',    name: 'Button 1 Max ADC',    min: 0, max: 4095, type: 'int' },
+    { id: 'btn2Min',    name: 'Button 2 Min ADC',    min: 0, max: 4095, type: 'int' },
+    { id: 'btn2Max',    name: 'Button 2 Max ADC',    min: 0, max: 4095, type: 'int' },
+    { id: 'btn3Min',    name: 'Button 3 Min ADC',    min: 0, max: 4095, type: 'int' },
+    { id: 'btn3Max',    name: 'Button 3 Max ADC',    min: 0, max: 4095, type: 'int' },
+    { id: 'btnNoPress', name: 'No-Press Threshold',  min: 0, max: 4095, type: 'int' },
   ];
   for (const f of fields) {
     const el = document.getElementById(f.id);
@@ -571,6 +578,19 @@ function validateSettings() {
       el.focus();
       return false;
     }
+  }
+  // Button ADC thresholds must form coherent, non-overlapping ranges
+  const btnVal = (id) => parseInt(document.getElementById(id).value, 10);
+  const b1Min = btnVal('btn1Min'), b1Max = btnVal('btn1Max');
+  const b2Min = btnVal('btn2Min'), b2Max = btnVal('btn2Max');
+  const b3Min = btnVal('btn3Min'), b3Max = btnVal('btn3Max');
+  if (b1Min >= b1Max || b2Min >= b2Max || b3Min >= b3Max) {
+    alert('Each button Min must be less than its Max.');
+    return false;
+  }
+  if (b1Max > b2Min || b2Max > b3Min) {
+    alert('Button ADC ranges must not overlap.');
+    return false;
   }
   return true;
 }

--- a/data/web/app.js
+++ b/data/web/app.js
@@ -559,7 +559,7 @@ function validateSettings() {
     { id: 'btn2Max',    name: 'Button 2 Max ADC',    min: 0, max: 4095, type: 'int' },
     { id: 'btn3Min',    name: 'Button 3 Min ADC',    min: 0, max: 4095, type: 'int' },
     { id: 'btn3Max',    name: 'Button 3 Max ADC',    min: 0, max: 4095, type: 'int' },
-    { id: 'btnNoPress', name: 'No-Press Threshold',  min: 0, max: 4095, type: 'int' },
+    { id: 'btnNoPress', name: 'No-Press Threshold',  min: 0, max: 4096, type: 'int' },
   ];
   for (const f of fields) {
     const el = document.getElementById(f.id);

--- a/data/web/index.html
+++ b/data/web/index.html
@@ -347,7 +347,7 @@
   <div class="telemetry-grid">
     <div class="input-group">
       <label for="btnNoPress">No-Press Threshold</label>
-      <input type="number" id="btnNoPress" min="0" max="4095" step="1" value="4096">
+      <input type="number" id="btnNoPress" min="0" max="4096" step="1" value="4096">
       <span class="input-hint">Values above this are ignored · 4096 = no-op (S3 reads full scale)</span>
     </div>
     <div class="input-group" style="visibility:hidden;">

--- a/data/web/index.html
+++ b/data/web/index.html
@@ -307,6 +307,54 @@
     </div>
   </div>
 
+  <h2>🔘 Button Thresholds (NORVI)</h2>
+  <div class="telemetry-grid">
+    <div class="input-group">
+      <label for="btn1Min">Button 1 Min ADC</label>
+      <input type="number" id="btn1Min" min="0" max="4095" step="1" value="3100">
+      <span class="input-hint">Lower bound of Button 1 range · Measured: ~3275–3456</span>
+    </div>
+    <div class="input-group">
+      <label for="btn1Max">Button 1 Max ADC</label>
+      <input type="number" id="btn1Max" min="0" max="4095" step="1" value="3520">
+      <span class="input-hint">Upper bound of Button 1 range</span>
+    </div>
+  </div>
+  <div class="telemetry-grid">
+    <div class="input-group">
+      <label for="btn2Min">Button 2 Min ADC</label>
+      <input type="number" id="btn2Min" min="0" max="4095" step="1" value="3520">
+      <span class="input-hint">Lower bound of Button 2 range · Measured: ~3579–3765</span>
+    </div>
+    <div class="input-group">
+      <label for="btn2Max">Button 2 Max ADC</label>
+      <input type="number" id="btn2Max" min="0" max="4095" step="1" value="3880">
+      <span class="input-hint">Upper bound of Button 2 range</span>
+    </div>
+  </div>
+  <div class="telemetry-grid">
+    <div class="input-group">
+      <label for="btn3Min">Button 3 Min ADC</label>
+      <input type="number" id="btn3Min" min="0" max="4095" step="1" value="3880">
+      <span class="input-hint">Lower bound of Button 3 range · Measured: ~4095 (full scale)</span>
+    </div>
+    <div class="input-group">
+      <label for="btn3Max">Button 3 Max ADC</label>
+      <input type="number" id="btn3Max" min="0" max="4095" step="1" value="4095">
+      <span class="input-hint">Upper bound of Button 3 range</span>
+    </div>
+  </div>
+  <div class="telemetry-grid">
+    <div class="input-group">
+      <label for="btnNoPress">No-Press Threshold</label>
+      <input type="number" id="btnNoPress" min="0" max="4095" step="1" value="4096">
+      <span class="input-hint">Values above this are ignored · 4096 = no-op (S3 reads full scale)</span>
+    </div>
+    <div class="input-group" style="visibility:hidden;">
+      <div style="height:1px;"></div>
+    </div>
+  </div>
+
   <h2>⏱️ Timer Schedule</h2>
   <div class="telemetry-grid">
     <div class="input-group">

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -68,6 +68,13 @@ static constexpr const char *kSetRed = "set_red";
 static constexpr const char *kSetCircThresh = "set_circth";
 static constexpr const char *kSetCircFactor = "set_circfa";
 static constexpr const char *kSetCircMax = "set_circmx";
+static constexpr const char *kSetBtn1Min = "set_btn1min";
+static constexpr const char *kSetBtn1Max = "set_btn1max";
+static constexpr const char *kSetBtn2Min = "set_btn2min";
+static constexpr const char *kSetBtn2Max = "set_btn2max";
+static constexpr const char *kSetBtn3Min = "set_btn3min";
+static constexpr const char *kSetBtn3Max = "set_btn3max";
+static constexpr const char *kSetBtnNoPress = "set_btnnop";
 static constexpr const char *kAdmPass = "adm_pass";
 static constexpr const char *kCfgConfigured = "cfg_configured";
 
@@ -108,6 +115,13 @@ bool ConfigManager::load() {
   settings_.tempCircThreshold = prefs.getDouble(kSetCircThresh, 24.0);
   settings_.tempCircFactor = prefs.getUShort(kSetCircFactor, 30);
   settings_.tempCircMaxRuntime = prefs.getUShort(kSetCircMax, 720);
+  settings_.btn1Min = prefs.getUShort(kSetBtn1Min, 3100);
+  settings_.btn1Max = prefs.getUShort(kSetBtn1Max, 3520);
+  settings_.btn2Min = prefs.getUShort(kSetBtn2Min, 3520);
+  settings_.btn2Max = prefs.getUShort(kSetBtn2Max, 3880);
+  settings_.btn3Min = prefs.getUShort(kSetBtn3Min, 3880);
+  settings_.btn3Max = prefs.getUShort(kSetBtn3Max, 4095);
+  settings_.btnNoPress = prefs.getUShort(kSetBtnNoPress, 4096);
 
   adminPasswordHash_ = prefs.getString(kAdmPass, kDefaultPasswordHash);
   configured_ = prefs.getBool(kCfgConfigured, false);
@@ -147,6 +161,13 @@ bool ConfigManager::save() {
   prefs.putDouble(kSetCircThresh, settings_.tempCircThreshold);
   prefs.putUShort(kSetCircFactor, settings_.tempCircFactor);
   prefs.putUShort(kSetCircMax, settings_.tempCircMaxRuntime);
+  prefs.putUShort(kSetBtn1Min, settings_.btn1Min);
+  prefs.putUShort(kSetBtn1Max, settings_.btn1Max);
+  prefs.putUShort(kSetBtn2Min, settings_.btn2Min);
+  prefs.putUShort(kSetBtn2Max, settings_.btn2Max);
+  prefs.putUShort(kSetBtn3Min, settings_.btn3Min);
+  prefs.putUShort(kSetBtn3Max, settings_.btn3Max);
+  prefs.putUShort(kSetBtnNoPress, settings_.btnNoPress);
 
   prefs.putString(kAdmPass, adminPasswordHash_);
   prefs.putBool(kCfgConfigured, configured_);

--- a/src/ConfigManager.hpp
+++ b/src/ConfigManager.hpp
@@ -45,14 +45,14 @@ struct ControllerSettings {
   String opMode = "auto";
   long timeLossGreenHours = 1;
   long timeLossRedHours = 24;
-  int timezoneIndex = 0;  ///< Index into TimeClientHelper timezone table
-  uint16_t btn1Min = 3100;    ///< NORVI button 1 ADC range min
-  uint16_t btn1Max = 3520;    ///< NORVI button 1 ADC range max
-  uint16_t btn2Min = 3520;    ///< NORVI button 2 ADC range min
-  uint16_t btn2Max = 3880;    ///< NORVI button 2 ADC range max
-  uint16_t btn3Min = 3880;    ///< NORVI button 3 ADC range min
-  uint16_t btn3Max = 4095;    ///< NORVI button 3 ADC range max
-  uint16_t btnNoPress = 4096; ///< NORVI no-press threshold (no-op, > ADC max)
+  int timezoneIndex = 0;       ///< Index into TimeClientHelper timezone table
+  uint16_t btn1Min = 3100;     ///< NORVI button 1 ADC range min
+  uint16_t btn1Max = 3520;     ///< NORVI button 1 ADC range max
+  uint16_t btn2Min = 3520;     ///< NORVI button 2 ADC range min
+  uint16_t btn2Max = 3880;     ///< NORVI button 2 ADC range max
+  uint16_t btn3Min = 3880;     ///< NORVI button 3 ADC range min
+  uint16_t btn3Max = 4095;     ///< NORVI button 3 ADC range max
+  uint16_t btnNoPress = 4096;  ///< NORVI no-press threshold (no-op, > ADC max)
 };
 
 /**

--- a/src/ConfigManager.hpp
+++ b/src/ConfigManager.hpp
@@ -46,6 +46,13 @@ struct ControllerSettings {
   long timeLossGreenHours = 1;
   long timeLossRedHours = 24;
   int timezoneIndex = 0;  ///< Index into TimeClientHelper timezone table
+  uint16_t btn1Min = 3100;    ///< NORVI button 1 ADC range min
+  uint16_t btn1Max = 3520;    ///< NORVI button 1 ADC range max
+  uint16_t btn2Min = 3520;    ///< NORVI button 2 ADC range min
+  uint16_t btn2Max = 3880;    ///< NORVI button 2 ADC range max
+  uint16_t btn3Min = 3880;    ///< NORVI button 3 ADC range min
+  uint16_t btn3Max = 4095;    ///< NORVI button 3 ADC range max
+  uint16_t btnNoPress = 4096; ///< NORVI no-press threshold (no-op, > ADC max)
 };
 
 /**

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -19,6 +19,7 @@
 
 #include <Arduino.h>
 #include "Config.hpp"
+#include "ConfigManager.hpp"
 #include "LogCapture.hpp"
 
 namespace PoolController {
@@ -51,12 +52,31 @@ NorviButtonHandler::ButtonLongPressCallback NorviButtonHandler::cbButton3Long_ =
 uint32_t NorviButtonHandler::pressStartMs_ = 0;
 uint32_t NorviButtonHandler::releasePendingMs_ = 0;
 
+// ADC thresholds — defaults are the 2026-08-16 calibrated values; begin()
+// overwrites them from ConfigManager (NVS) so they are user-configurable.
+uint16_t NorviButtonHandler::THRESH_BTN1_MIN{3100};
+uint16_t NorviButtonHandler::THRESH_BTN1_MAX{3520};
+uint16_t NorviButtonHandler::THRESH_BTN2_MIN{3520};
+uint16_t NorviButtonHandler::THRESH_BTN2_MAX{3880};
+uint16_t NorviButtonHandler::THRESH_BTN3_MIN{3880};
+uint16_t NorviButtonHandler::THRESH_BTN3_MAX{4095};
+uint16_t NorviButtonHandler::THRESH_NO_PRESS{4096};
+
 // ═══════════════════════════════════════════════════════════════════════════
 
 void NorviButtonHandler::begin() {
   LOG_INFO("• NorviButtonHandler initializing on ADC GPIO%d...\n", PIN_BUTTON_ADC);
 
   pinMode(PIN_BUTTON_ADC, INPUT);
+
+  // Load configurable ADC thresholds from NVS (defaults = calibrated values)
+  THRESH_BTN1_MIN = ConfigManager::getSettings().btn1Min;
+  THRESH_BTN1_MAX = ConfigManager::getSettings().btn1Max;
+  THRESH_BTN2_MIN = ConfigManager::getSettings().btn2Min;
+  THRESH_BTN2_MAX = ConfigManager::getSettings().btn2Max;
+  THRESH_BTN3_MIN = ConfigManager::getSettings().btn3Min;
+  THRESH_BTN3_MAX = ConfigManager::getSettings().btn3Max;
+  THRESH_NO_PRESS = ConfigManager::getSettings().btnNoPress;
 
   // Take an initial sample to let the ADC stabilise
   analogRead(PIN_BUTTON_ADC);
@@ -89,7 +109,7 @@ void NorviButtonHandler::loop() {
   static uint32_t lastStableTime_ = 0;
 
   // Fast-attack: a genuine press/release changes the button range — even
-  // when the ADC delta is small (no-press 3800 → S3 3700 = 100). Base the
+  // when the ADC delta is small (no-press ~2700 → S1 ~3400 = 700). Base the
   // re-initialization on button-range transitions so every valid press is
   // caught within one sample instead of a full moving-average window. The
   // transition also restarts the stability window, so a single-sample glitch

--- a/src/NorviButtonHandler.cpp
+++ b/src/NorviButtonHandler.cpp
@@ -69,14 +69,7 @@ void NorviButtonHandler::begin() {
 
   pinMode(PIN_BUTTON_ADC, INPUT);
 
-  // Load configurable ADC thresholds from NVS (defaults = calibrated values)
-  THRESH_BTN1_MIN = ConfigManager::getSettings().btn1Min;
-  THRESH_BTN1_MAX = ConfigManager::getSettings().btn1Max;
-  THRESH_BTN2_MIN = ConfigManager::getSettings().btn2Min;
-  THRESH_BTN2_MAX = ConfigManager::getSettings().btn2Max;
-  THRESH_BTN3_MIN = ConfigManager::getSettings().btn3Min;
-  THRESH_BTN3_MAX = ConfigManager::getSettings().btn3Max;
-  THRESH_NO_PRESS = ConfigManager::getSettings().btnNoPress;
+  applySettings();
 
   // Take an initial sample to let the ADC stabilise
   analogRead(PIN_BUTTON_ADC);
@@ -88,6 +81,19 @@ void NorviButtonHandler::begin() {
   LOG_INFO("  ◦ Button 2 ADC range: %u–%u\n", THRESH_BTN2_MIN, THRESH_BTN2_MAX);
   LOG_INFO("  ◦ Button 3 ADC range: %u–%u\n", THRESH_BTN3_MIN, THRESH_BTN3_MAX);
   LOG_INFO("✓ NorviButtonHandler initialized\n");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+void NorviButtonHandler::applySettings() {
+  // Load configurable ADC thresholds from NVS (defaults = calibrated values)
+  THRESH_BTN1_MIN = ConfigManager::getSettings().btn1Min;
+  THRESH_BTN1_MAX = ConfigManager::getSettings().btn1Max;
+  THRESH_BTN2_MIN = ConfigManager::getSettings().btn2Min;
+  THRESH_BTN2_MAX = ConfigManager::getSettings().btn2Max;
+  THRESH_BTN3_MIN = ConfigManager::getSettings().btn3Min;
+  THRESH_BTN3_MAX = ConfigManager::getSettings().btn3Max;
+  THRESH_NO_PRESS = ConfigManager::getSettings().btnNoPress;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/NorviButtonHandler.hpp
+++ b/src/NorviButtonHandler.hpp
@@ -36,11 +36,11 @@ namespace PoolController {
  * ~50 ms intervals, applies hysteresis for noise rejection, and fires
  * callbacks on press events.
  *
- * Default thresholds (12-bit ADC, 0–4095):
- *   Button 1:     200 – 1200
- *   Button 2:    1400 – 2500
- *   Button 3:    2700 – 3700
- *   No press:    > 3800
+ * Calibrated thresholds (12-bit ADC, 0–4095) from live measurements:
+ *   No press:    < 3100   (resting level oscillates ~2610–2990)
+ *   Button 1:    3100 – 3520
+ *   Button 2:    3520 – 3880
+ *   Button 3:    3880 – 4095
  */
 class NorviButtonHandler {
 public:
@@ -172,16 +172,24 @@ private:
   static uint32_t releasePendingMs_;
 
   // ── ADC thresholds (12-bit, 0–4095) ──────────────────────────────────
-  // These are typical ranges for the NORVI AE01-R resistor ladder.
-  // Adjust if needed based on serial debug output.
+  // Calibrated from live measurements on the NORVI AE01-R (2026-08-16):
+  //   No press: ~2610–2990 (oscillates; must map to NONE)
+  //   Button 1: ~3275–3456
+  //   Button 2: ~3579–3765
+  //   Button 3: ~4095 (full scale)
+  // The resistor ladder pulls the ADC pin UP toward VCC on press.
+  // Boundaries sit at the midpoints between adjacent levels.
+  // THRESH_NO_PRESS is a no-op (4096 > ADC max) — S3 reads full scale.
+  // Values are loaded from ConfigManager (NVS) in begin(); the defaults
+  // below are the calibrated values and can be overridden via the web UI.
 
-  static constexpr uint16_t THRESH_BTN1_MIN{200};
-  static constexpr uint16_t THRESH_BTN1_MAX{1200};
-  static constexpr uint16_t THRESH_BTN2_MIN{1400};
-  static constexpr uint16_t THRESH_BTN2_MAX{2500};
-  static constexpr uint16_t THRESH_BTN3_MIN{2700};
-  static constexpr uint16_t THRESH_BTN3_MAX{3700};
-  static constexpr uint16_t THRESH_NO_PRESS{3800};
+  static uint16_t THRESH_BTN1_MIN;
+  static uint16_t THRESH_BTN1_MAX;
+  static uint16_t THRESH_BTN2_MIN;
+  static uint16_t THRESH_BTN2_MAX;
+  static uint16_t THRESH_BTN3_MIN;
+  static uint16_t THRESH_BTN3_MAX;
+  static uint16_t THRESH_NO_PRESS;
 };
 
 }  // namespace PoolController

--- a/src/NorviButtonHandler.hpp
+++ b/src/NorviButtonHandler.hpp
@@ -63,6 +63,13 @@ public:
   static void begin();
 
   /**
+   * @brief Reload ADC thresholds from ConfigManager (NVS).
+   * Called after settings changes so new thresholds apply to the running
+   * handler without a reboot.
+   */
+  static void applySettings();
+
+  /**
    * @brief Sample and debounce buttons.
    * Must be called regularly from PoolController::loop().
    */

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -40,6 +40,10 @@
 #include "Version.h"
 #include "LogCapture.hpp"
 
+#ifdef NORVI_AE01_R
+#include "NorviButtonHandler.hpp"
+#endif
+
 namespace PoolController {
 
 // File-scoped state for streaming LittleFS upload (used by handleFsUploadStream)
@@ -776,6 +780,12 @@ void WebPortal::apiSaveConfig() {
     ConfigManager::getSettings().timeLossRedHours = server_.arg("red").toInt();
 
     ConfigManager::save();
+
+#ifdef NORVI_AE01_R
+    // Apply button thresholds to the running handler immediately so the
+    // new values take effect without a reboot (P2 review fix).
+    NorviButtonHandler::applySettings();
+#endif
 
     // Apply timezone change to running clock immediately (P2)
     setTimezoneIndex(ConfigManager::getSettings().timezoneIndex);

--- a/src/WebPortal.cpp
+++ b/src/WebPortal.cpp
@@ -666,6 +666,13 @@ void WebPortal::apiGetConfig() {
   settingsObj["timezone"] = ConfigManager::getSettings().timezoneIndex;
   settingsObj["time_loss_green_hours"] = ConfigManager::getSettings().timeLossGreenHours;
   settingsObj["time_loss_red_hours"] = ConfigManager::getSettings().timeLossRedHours;
+  settingsObj["btn1_min"] = ConfigManager::getSettings().btn1Min;
+  settingsObj["btn1_max"] = ConfigManager::getSettings().btn1Max;
+  settingsObj["btn2_min"] = ConfigManager::getSettings().btn2Min;
+  settingsObj["btn2_max"] = ConfigManager::getSettings().btn2Max;
+  settingsObj["btn3_min"] = ConfigManager::getSettings().btn3Min;
+  settingsObj["btn3_max"] = ConfigManager::getSettings().btn3Max;
+  settingsObj["btn_no_press"] = ConfigManager::getSettings().btnNoPress;
   settingsObj["timer_start_hour"] = operationModeNode.getTimerSetting().timerStartHour;
   settingsObj["timer_start_min"] = operationModeNode.getTimerSetting().timerStartMinutes;
   settingsObj["timer_end_hour"] = operationModeNode.getTimerSetting().timerEndHour;
@@ -750,6 +757,20 @@ void WebPortal::apiSaveConfig() {
       ConfigManager::getSettings().tempCircFactor = server_.arg("circ_factor").toInt();
     if (server_.hasArg("circ_max_runtime"))
       ConfigManager::getSettings().tempCircMaxRuntime = server_.arg("circ_max_runtime").toInt();
+    if (server_.hasArg("btn1_min"))
+      ConfigManager::getSettings().btn1Min = server_.arg("btn1_min").toInt();
+    if (server_.hasArg("btn1_max"))
+      ConfigManager::getSettings().btn1Max = server_.arg("btn1_max").toInt();
+    if (server_.hasArg("btn2_min"))
+      ConfigManager::getSettings().btn2Min = server_.arg("btn2_min").toInt();
+    if (server_.hasArg("btn2_max"))
+      ConfigManager::getSettings().btn2Max = server_.arg("btn2_max").toInt();
+    if (server_.hasArg("btn3_min"))
+      ConfigManager::getSettings().btn3Min = server_.arg("btn3_min").toInt();
+    if (server_.hasArg("btn3_max"))
+      ConfigManager::getSettings().btn3Max = server_.arg("btn3_max").toInt();
+    if (server_.hasArg("btn_no_press"))
+      ConfigManager::getSettings().btnNoPress = server_.arg("btn_no_press").toInt();
     ConfigManager::getSettings().timezoneIndex = server_.arg("timezone").toInt();
     ConfigManager::getSettings().timeLossGreenHours = server_.arg("green").toInt();
     ConfigManager::getSettings().timeLossRedHours = server_.arg("red").toInt();

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SERVICE_SOURCES
   ${PROJ_ROOT}/src/LocalSettingsMenu.cpp
   ${PROJ_ROOT}/src/Ky040Decoder.cpp
   ${PROJ_ROOT}/src/OlimexEncoderHandler.cpp
+  ${PROJ_ROOT}/src/NorviButtonHandler.cpp
 )
 
 # Mock sources (compiled once)

--- a/test/native/mocks/ConfigManager.hpp
+++ b/test/native/mocks/ConfigManager.hpp
@@ -20,6 +20,13 @@ struct Settings {
   float tempCircThreshold = 24.0f;
   int tempCircFactor = 30;
   int tempCircMaxRuntime = 720;
+  uint16_t btn1Min = 3100;
+  uint16_t btn1Max = 3520;
+  uint16_t btn2Min = 3520;
+  uint16_t btn2Max = 3880;
+  uint16_t btn3Min = 3880;
+  uint16_t btn3Max = 4095;
+  uint16_t btnNoPress = 4096;
 };
 
 struct WiFiConfig {


### PR DESCRIPTION
## Problem

The NORVI AE01-R front panel repeatedly switched the operation mode without any button being pressed. Log analysis showed `[MODE_CHANGED] ... source=button:S3/menu` events firing spontaneously.

## Root cause

The front-panel buttons are read via a resistor ladder on ADC GPIO32 that pulls the signal UP toward VCC on press. Live measurements (via `/api/logs` debug capture):

| State | ADC level |
|---|---|
| No press (resting) | ~2610–2990 (oscillates) |
| Button 1 | ~3275–3456 |
| Button 2 | ~3579–3765 |
| Button 3 | ~4095 (full scale) |

The old thresholds (`B3_MIN=2700`, `NO_PRESS=3800`) sat **inside** the resting oscillation, so the resting level itself crossed the Button-3 boundary and each S3 press/release pair (open menu + confirm, menu defaults to MODE) cycled the operation mode.

## Changes

- **`fix(logging)`** — trace operation mode command sources (b41fc17), enabling diagnosis
- **8 × debounce fixes** (0fee59b…74ea4c3) — fast-attack filter, stability windows, release debouncing, long-press evaluation
- **Threshold calibration** — B1 3100–3520, B2 3520–3880, B3 3880–4095, no-press 4096 (no-op, S3 reads full scale); midpoints between measured levels
- **Configurable thresholds** (new) — the 7 ADC thresholds are now stored in NVS via `ConfigManager` (defaults = calibrated values) and editable in the web UI *Pool settings* tab, so future ADC drift (resting level rose ~2445 → ~2700 over weeks) can be corrected without a firmware reflash

## Verification

- ✅ `pio run -e norvi_ae01_r` SUCCESS (Flash 97.1%)
- ✅ Native tests: 109 suites / 202 assertions / 0 failures
- ✅ OTA deployed to the live device; boot verified, no mode changes since
- ✅ New settings exposed via `/api/config` (`btn1_min` … `btn_no_press`)